### PR TITLE
Increment version for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "coreaudio-rs"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]


### PR DESCRIPTION
Now at `0.2.0`.