### PR TITLE
Updated coreaudio-sys and libc versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ homepage = "https://github.com/RustAudio/coreaudio-rs"
 num = "0.1.27"
 
 [dependencies]
-coreaudio-sys = "0.1.1"
-libc = "0.1.10"
+coreaudio-sys = "0.1.2"
+libc = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "coreaudio-rs"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]


### PR DESCRIPTION
This makes sure the libc dependency for this crate is the same as coreaudio-sys', which fixes the build after some recent libc changes.