### PR TITLE
Updated travis config to test beta again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
 - stable
+- beta
 - nightly
 notifications:
   email:
@@ -9,7 +10,8 @@ os:
 - osx
 matrix:
   allow_failures:
-  - os: linux
+  - rust: beta
+  - rust: nightly
 env:
   matrix:
   - LD_LIBRARY_PATH: /usr/local/lib


### PR DESCRIPTION
Also added beta and nightly builds to the "allowed failures" list. This just helps us stay ahead of the curve in terms of potentially breaking changes with future version of rust and/or the libs we depend on.

None of the code is changed, so no need to publish with just this change.