### PR TITLE
[Breaking Change] Remove unnecessary lifetimes. Add `action_flags::Handle` type. Update to bitflags 0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ homepage = "https://github.com/RustAudio/coreaudio-rs"
 name = "coreaudio"
 
 [dependencies]
-bitflags = "0.3.2"
-coreaudio-sys = "0.1.2"
-libc = "0.2.1"
+bitflags = "0.7"
+coreaudio-sys = "0.1"
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "coreaudio-rs"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]

--- a/src/audio_unit/audio_format.rs
+++ b/src/audio_unit/audio_format.rs
@@ -279,7 +279,7 @@ pub mod standard_flags {
         /// the **AudioFormat** type.
         /// 
         /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        flags StandardFlags: u32 {
+        pub flags StandardFlags: u32 {
             /// Set for floating point, clear for integer.
             ///
             /// **Available** in OS X v10.2 and later.
@@ -337,7 +337,7 @@ pub mod linear_pcm_flags {
         /// the **AudioFormat** type.
         ///
         /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        flags LinearPCMFlags: u32 {
+        pub flags LinearPCMFlags: u32 {
             /// Synonmyn for the **IS_FLOAT** **StandardFlags**.
             ///
             /// **Available** in OS X v10.0 and later.
@@ -404,7 +404,7 @@ pub mod apple_lossless_flags {
         /// the **AudioFormat** type.
         ///
         /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        flags AppleLosslessFlags: u32 {
+        pub flags AppleLosslessFlags: u32 {
             /// Sourced from 16 bit native endian signed integer data.
             const BIT_16_SOURCE_DATA = 1,
             /// Sourced from 20 bit native endian signed integer data aligned high in 24 bits.
@@ -483,7 +483,7 @@ pub mod audio_time_stamp_flags {
         /// **Available** in OS X v10.0 and later.
         ///
         /// Original Documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Time_Stamp_Flags).
-        flags AudioTimeStampFlags: u32 {
+        pub flags AudioTimeStampFlags: u32 {
             /// The sample frame time is valid.
             const SAMPLE_TIME_VALID = 1,
             /// The host time is valid.

--- a/src/audio_unit/mod.rs
+++ b/src/audio_unit/mod.rs
@@ -277,11 +277,13 @@ impl AudioUnit {
 }
 
 
+unsafe impl Send for AudioUnit {}
+
+
 impl Drop for AudioUnit {
     fn drop(&mut self) {
         unsafe {
             use error;
-            use std::error::Error;
 
             // We don't want to panic in `drop`, so we'll ignore returned errors.
             //

--- a/src/audio_unit/render_callback.rs
+++ b/src/audio_unit/render_callback.rs
@@ -224,7 +224,7 @@ pub mod action_flags {
     use bindings::audio_unit as au;
 
     bitflags!{
-        flags ActionFlags: u32 {
+        pub flags ActionFlags: u32 {
             /// Called on a render notification Proc, which is called either before or after the
             /// render operation of the audio unit. If this flag is set, the proc is being called
             /// before the render operation is performed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,7 @@
 //! eventually we'd like to cover at least the majority of the C API.
 
 #[macro_use] extern crate bitflags;
-extern crate coreaudio_sys;
-pub use coreaudio_sys as bindings;
+pub extern crate coreaudio_sys as bindings;
 
 extern crate libc;
 


### PR DESCRIPTION
This removes the artificial lifetimes imposed on the `render_callback::Args` and `NonInterleaved` types. These were originally added to ensure that the args or buffer never outlived the scope of the callback, however this was under the incorrect assumption that the callback was "push"ing for data and not "pull"ing which is actually the case.

Replaces the `ActionFlags` field of the `render_callback::Args` with an `action_flags::Handle` type which more correctly represents the behaviour of the original coreaudio API. This type allows the callback to provide various "hint"s to the audio unit. As a result, `render_callback::Args` is no longer `Clone` or `Copy`, however this shouldn't be much of an issue.

Send is now implemented for `NonInterleaved` and `AudioUnit`.