### PR TITLE
Add Remote I/O unit for ios

### DIFF
--- a/src/audio_unit/types.rs
+++ b/src/audio_unit/types.rs
@@ -446,5 +446,12 @@ pub enum IOType {
     ///
     /// **Available** in OS X v10.7 and later.
     VoiceProcessingIO = 1987078511,
+    /// Connects to device hardware for input, output, or simultaneous input and output.
+    /// Use it for playback, recording, or low-latency simultaneous input and output where echo
+    /// cancelation is not needed.
+    ///
+    /// See https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/UsingSpecificAudioUnits/UsingSpecificAudioUnits.html
+    /// **Available** in iOS.
+    RemoteIO = 1919512419,
 }
 


### PR DESCRIPTION
iOS provides three I/O (input/output) units. The vast majority of audio-unit applications use the Remote I/O unit, which connects to input and output audio hardware and provides low-latency access to individual incoming and outgoing audio sample values. For VoIP apps, the Voice-Processing I/O unit extends the Remote I/O unit by adding acoustic echo cancelation and other features. To send audio back to your application rather than to output audio hardware, use the Generic Output unit.

See https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/UsingSpecificAudioUnits/UsingSpecificAudioUnits.html