### PR TITLE
Publish 0.7 for addition of Remote I/O unit for iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-
 name = "coreaudio-rs"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]
@@ -14,6 +13,6 @@ homepage = "https://github.com/RustAudio/coreaudio-rs"
 name = "coreaudio"
 
 [dependencies]
-bitflags = "0.7"
+bitflags = "1.0"
 coreaudio-sys = "0.1"
 libc = "0.2"

--- a/src/audio_unit/audio_format.rs
+++ b/src/audio_unit/audio_format.rs
@@ -6,12 +6,6 @@
 
 use libc;
 
-pub use self::standard_flags::StandardFlags;
-pub use self::linear_pcm_flags::LinearPCMFlags;
-pub use self::apple_lossless_flags::AppleLosslessFlags;
-pub use self::audio_time_stamp_flags::AudioTimeStampFlags;
-
-
 /// A type-safe representation of both the `AudioFormatId` and their associated flags.
 #[derive(Copy, Clone, Debug)]
 #[allow(non_camel_case_types)]
@@ -19,7 +13,7 @@ pub enum AudioFormat {
     /// Linear PCM; a non-compressed audio data format with one frame per packet.
     ///
     /// **Available** in OS X v10.0 and later.
-    LinearPCM(LinearPCMFlags),     // = 1819304813,
+    LinearPCM(LinearPcmFlags),     // = 1819304813,
     /// An AC-3 codec.
     ///
     /// **Available** in OS X v10.2 and later.
@@ -183,7 +177,7 @@ impl AudioFormat {
     /// Convert from the FFI C format and flags to a typesafe Rust enum representation.
     pub fn from_format_and_flag(format: libc::c_uint, flag: Option<u32>) -> Option<AudioFormat> {
         match (format, flag) {
-            (1819304813, Some(i)) => Some(AudioFormat::LinearPCM(LinearPCMFlags::from_bits_truncate(i))),
+            (1819304813, Some(i)) => Some(AudioFormat::LinearPCM(LinearPcmFlags::from_bits_truncate(i))),
             (1633889587, _)       => Some(AudioFormat::AC3),
             (1667326771, Some(i)) => Some(AudioFormat::F60958AC3(StandardFlags::from_bits_truncate(i))),
             (1768775988, _)       => Some(AudioFormat::AppleIMA4),
@@ -268,155 +262,143 @@ impl AudioFormat {
 }
 
 
-/// A wrapper around the const **StandardFlags**.
-pub mod standard_flags {
-    bitflags! {
-        /// Standard flags for use in the **F60958AC3** **AudioFormat** variant.
+bitflags! {
+    /// Standard flags for use in the **F60958AC3** **AudioFormat** variant.
+    ///
+    /// Note: In the original Core Audio API these are consolidated with what we have named the
+    /// **StandardFlags** and **AppleLosslessFlags** types under the `AudioFormatFlag` type. We
+    /// have chosen to separate these for greater type safety and clearer compatibility with
+    /// the **AudioFormat** type.
+    /// 
+    /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
+    pub struct StandardFlags: u32 {
+        /// Set for floating point, clear for integer.
         ///
-        /// Note: In the original Core Audio API these are consolidated with what we have named the
-        /// **StandardFlags** and **AppleLosslessFlags** types under the `AudioFormatFlag` type. We
-        /// have chosen to separate these for greater type safety and clearer compatibility with
-        /// the **AudioFormat** type.
-        /// 
-        /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        pub struct StandardFlags: u32 {
-            /// Set for floating point, clear for integer.
-            ///
-            /// **Available** in OS X v10.2 and later.
-            const IS_FLOAT = 1;
-            /// Set for big endian, clear for little endian.
-            ///
-            /// **Available** in OS X v10.2 and later.
-            const IS_BIG_ENDIAN = 2;
-            /// Set for signed integer, clear for unsigned integer.
-            ///
-            /// Note: This is only valid if `IS_FLOAT` is clear.
-            ///
-            /// **Available** in OS X v10.2 and later.
-            const IS_SIGNED_INTEGER = 4;
-            /// Set if the sample bits occupy the entire available bits for the channel, clear if they
-            /// are high- or low-aligned within the channel.
-            ///
-            /// **Available** in OS X v10.2 and later.
-            const IS_PACKED = 8;
-            /// Set if the sample bits are placed into the high bits of the channel, clear for low bit
-            /// placement.
-            ///
-            /// Note: This is only valid if `IS_PACKED` is clear.
-            ///
-            /// **Available** in OS X v10.2 and later.
-            const IS_ALIGNED_HIGH = 16;
-            /// Set if the sample for each channel are located contiguously and the channels are laid
-            /// out end to end.
-            ///
-            /// Clear if the samples for each frame are laid out contiguously and the frames laid out
-            /// end to end.
-            ///
-            /// **Available** in OS X v10.2 and later.
-            const IS_NON_INTERLEAVED = 32;
-            /// Set to indicate when a format is nonmixable.
-            ///
-            /// Note: that this flag is only used when interacting with the HAL's stream format
-            /// information. It is **not** valid for any other use.
-            ///
-            /// **Available** in OS X v10.3 and later.
-            const IS_NON_MIXABLE = 64;
-        }
-    }
-}
-
-
-/// A wrapper around the const **LinearPCMFlags**.
-pub mod linear_pcm_flags {
-    bitflags! {
-        /// Flags for use within the **LinearPCM** **AudioFormat**.
+        /// **Available** in OS X v10.2 and later.
+        const IS_FLOAT = 1;
+        /// Set for big endian, clear for little endian.
         ///
-        /// Note: In the original Core Audio API these are consolidated with what we have named the
-        /// **StandardFlags** and **AppleLosslessFlags** types under the `AudioFormatFlag` type. We
-        /// have chosen to separate these for greater type safety and clearer compatibility with
-        /// the **AudioFormat** type.
+        /// **Available** in OS X v10.2 and later.
+        const IS_BIG_ENDIAN = 2;
+        /// Set for signed integer, clear for unsigned integer.
         ///
-        /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        pub struct LinearPCMFlags: u32 {
-            /// Synonmyn for the **IS_FLOAT** **StandardFlags**.
-            ///
-            /// **Available** in OS X v10.0 and later.
-            const IS_FLOAT = 1;
-            /// Synonmyn for the **IS_BIG_ENDIAN** **StandardFlags**.
-            ///
-            /// **Available** in OS X v10.0 and later.
-            const IS_BIG_ENDIAN = 2;
-            /// Synonmyn for the **IS_SIGNED_INTEGER** **StandardFlags**.
-            ///
-            /// **Available** in OS X v10.0 and later.
-            const IS_SIGNED_INTEGER = 4;
-            /// Synonmyn for the **IS_PACKED** **StandardFlags**.
-            ///
-            /// **Available** in OS X v10.0 and later.
-            const IS_PACKED = 8;
-            /// Synonmyn for the **IS_ALIGNED_HIGH** **StandardFlags**.
-            ///
-            /// **Available** in OS X v10.0 and later.
-            const IS_ALIGNED_HIGH = 16;
-            /// Synonmyn for the **IS_NON_INTERLEAVED** **StandardFlags**.
-            ///
-            /// **Available** in OS X v10.2 and later.
-            const IS_NON_INTERLEAVED = 32;
-            /// Synonmyn for the **IS_NON_MIXABLE** **StandardFlags**.
-            ///
-            /// **Available** in OS X v10.3 and later.
-            const IS_NON_MIXABLE = 64;
-            /// The linear PCM flags contain a 6-bit bitfield indicating that an integer format is to
-            /// be interpreted as fixed point.
-            ///
-            /// The value indicates the number of bits are used to represent the fractional portion of
-            /// each sample value.
-            ///
-            /// This constant indicates the bit position (counting from the right) of the bitfield in
-            /// `mFormatFlags` field.
-            ///
-            /// TODO: Review whether or not this flag indicates that we need to treat LinearPCM format
-            /// uniquely in some way.
-            ///
-            /// **Available** in OS X v10.6 and later.
-            const FLAGS_SAMPLE_FRACTION_SHIFT = 7;
-            /// The number of fractional bits.
-            ///
-            /// `== (<other_flags> & FLAGS_SAMPLE_FRACTION_MASK) >> FLAGS_SAMPLE_FRACTION_SHIFT`
-            ///
-            /// **Available** in OS X v10.6 and later.
-            const FLAGS_SAMPLE_FRACTION_MASK = 8064;
-        }
-    }
-}
-
-
-/// A wrapper around the const **AppleLosslessFlags**.
-pub mod apple_lossless_flags {
-    bitflags! {
-        /// Flags set for Apple Lossless data.
+        /// Note: This is only valid if `IS_FLOAT` is clear.
+        ///
+        /// **Available** in OS X v10.2 and later.
+        const IS_SIGNED_INTEGER = 4;
+        /// Set if the sample bits occupy the entire available bits for the channel, clear if they
+        /// are high- or low-aligned within the channel.
+        ///
+        /// **Available** in OS X v10.2 and later.
+        const IS_PACKED = 8;
+        /// Set if the sample bits are placed into the high bits of the channel, clear for low bit
+        /// placement.
+        ///
+        /// Note: This is only valid if `IS_PACKED` is clear.
+        ///
+        /// **Available** in OS X v10.2 and later.
+        const IS_ALIGNED_HIGH = 16;
+        /// Set if the sample for each channel are located contiguously and the channels are laid
+        /// out end to end.
+        ///
+        /// Clear if the samples for each frame are laid out contiguously and the frames laid out
+        /// end to end.
+        ///
+        /// **Available** in OS X v10.2 and later.
+        const IS_NON_INTERLEAVED = 32;
+        /// Set to indicate when a format is nonmixable.
+        ///
+        /// Note: that this flag is only used when interacting with the HAL's stream format
+        /// information. It is **not** valid for any other use.
         ///
         /// **Available** in OS X v10.3 and later.
-        ///
-        /// Note: In the original Core Audio API these are consolidated with what we have named the
-        /// **StandardFlags** and **AppleLosslessFlags** types under the `AudioFormatFlag` type. We
-        /// have chosen to separate these for greater type safety and clearer compatibility with
-        /// the **AudioFormat** type.
-        ///
-        /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        pub struct AppleLosslessFlags: u32 {
-            /// Sourced from 16 bit native endian signed integer data.
-            const BIT_16_SOURCE_DATA = 1;
-            /// Sourced from 20 bit native endian signed integer data aligned high in 24 bits.
-            const BIT_20_SOURCE_DATA = 2;
-            /// Sourced from 24 bit native endian signed integer data.
-            const BIT_24_SOURCE_DATA = 3;
-            /// Sourced from 32 bit native endian signed integer data.
-            const BIT_32_SOURCE_DATA = 4;
-        }
+        const IS_NON_MIXABLE = 64;
     }
 }
 
+bitflags! {
+    /// Flags for use within the **LinearPCM** **AudioFormat**.
+    ///
+    /// Note: In the original Core Audio API these are consolidated with what we have named the
+    /// **StandardFlags** and **AppleLosslessFlags** types under the `AudioFormatFlag` type. We
+    /// have chosen to separate these for greater type safety and clearer compatibility with
+    /// the **AudioFormat** type.
+    ///
+    /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
+    pub struct LinearPcmFlags: u32 {
+        /// Synonmyn for the **IS_FLOAT** **StandardFlags**.
+        ///
+        /// **Available** in OS X v10.0 and later.
+        const IS_FLOAT = 1;
+        /// Synonmyn for the **IS_BIG_ENDIAN** **StandardFlags**.
+        ///
+        /// **Available** in OS X v10.0 and later.
+        const IS_BIG_ENDIAN = 2;
+        /// Synonmyn for the **IS_SIGNED_INTEGER** **StandardFlags**.
+        ///
+        /// **Available** in OS X v10.0 and later.
+        const IS_SIGNED_INTEGER = 4;
+        /// Synonmyn for the **IS_PACKED** **StandardFlags**.
+        ///
+        /// **Available** in OS X v10.0 and later.
+        const IS_PACKED = 8;
+        /// Synonmyn for the **IS_ALIGNED_HIGH** **StandardFlags**.
+        ///
+        /// **Available** in OS X v10.0 and later.
+        const IS_ALIGNED_HIGH = 16;
+        /// Synonmyn for the **IS_NON_INTERLEAVED** **StandardFlags**.
+        ///
+        /// **Available** in OS X v10.2 and later.
+        const IS_NON_INTERLEAVED = 32;
+        /// Synonmyn for the **IS_NON_MIXABLE** **StandardFlags**.
+        ///
+        /// **Available** in OS X v10.3 and later.
+        const IS_NON_MIXABLE = 64;
+        /// The linear PCM flags contain a 6-bit bitfield indicating that an integer format is to
+        /// be interpreted as fixed point.
+        ///
+        /// The value indicates the number of bits are used to represent the fractional portion of
+        /// each sample value.
+        ///
+        /// This constant indicates the bit position (counting from the right) of the bitfield in
+        /// `mFormatFlags` field.
+        ///
+        /// TODO: Review whether or not this flag indicates that we need to treat LinearPCM format
+        /// uniquely in some way.
+        ///
+        /// **Available** in OS X v10.6 and later.
+        const FLAGS_SAMPLE_FRACTION_SHIFT = 7;
+        /// The number of fractional bits.
+        ///
+        /// `== (<other_flags> & FLAGS_SAMPLE_FRACTION_MASK) >> FLAGS_SAMPLE_FRACTION_SHIFT`
+        ///
+        /// **Available** in OS X v10.6 and later.
+        const FLAGS_SAMPLE_FRACTION_MASK = 8064;
+    }
+}
+
+bitflags! {
+    /// Flags set for Apple Lossless data.
+    ///
+    /// **Available** in OS X v10.3 and later.
+    ///
+    /// Note: In the original Core Audio API these are consolidated with what we have named the
+    /// **StandardFlags** and **AppleLosslessFlags** types under the `AudioFormatFlag` type. We
+    /// have chosen to separate these for greater type safety and clearer compatibility with
+    /// the **AudioFormat** type.
+    ///
+    /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
+    pub struct AppleLosslessFlags: u32 {
+        /// Sourced from 16 bit native endian signed integer data.
+        const BIT_16_SOURCE_DATA = 1;
+        /// Sourced from 20 bit native endian signed integer data aligned high in 24 bits.
+        const BIT_20_SOURCE_DATA = 2;
+        /// Sourced from 24 bit native endian signed integer data.
+        const BIT_24_SOURCE_DATA = 3;
+        /// Sourced from 32 bit native endian signed integer data.
+        const BIT_32_SOURCE_DATA = 4;
+    }
+}
 
 /// "Used in the `mFormatFlags` field of an `AudioStreamBasicDescription` structure that
 /// describes an MPEG-4 audio stream to specify the type of MPEG-4 audio data.
@@ -474,26 +456,22 @@ impl Mpeg4ObjectId {
     }
 }
 
-
-/// A wrapper around the const **AudioTimeStampFlags**.
-pub mod audio_time_stamp_flags {
-    bitflags! {
-        /// "These flags indicate the valuid fields in an AudioTimeStamp structure."
-        ///
-        /// **Available** in OS X v10.0 and later.
-        ///
-        /// Original Documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Time_Stamp_Flags).
-        pub struct AudioTimeStampFlags: u32 {
-            /// The sample frame time is valid.
-            const SAMPLE_TIME_VALID = 1;
-            /// The host time is valid.
-            const HOST_TIME_VALID = 2;
-            /// The rate scalar is valid.
-            const RATE_SCALAR_VALID = 4;
-            /// The world clock time is valid.
-            const WORLD_CLOCK_TIME_VALID = 8;
-            /// The SMPTE time is valid.
-            const SMPTE_TIME_VALID = 16;
-        }
+bitflags! {
+    /// "These flags indicate the valuid fields in an AudioTimeStamp structure."
+    ///
+    /// **Available** in OS X v10.0 and later.
+    ///
+    /// Original Documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Time_Stamp_Flags).
+    pub struct AudioTimeStampFlags: u32 {
+        /// The sample frame time is valid.
+        const SAMPLE_TIME_VALID = 1;
+        /// The host time is valid.
+        const HOST_TIME_VALID = 2;
+        /// The rate scalar is valid.
+        const RATE_SCALAR_VALID = 4;
+        /// The world clock time is valid.
+        const WORLD_CLOCK_TIME_VALID = 8;
+        /// The SMPTE time is valid.
+        const SMPTE_TIME_VALID = 16;
     }
 }

--- a/src/audio_unit/audio_format.rs
+++ b/src/audio_unit/audio_format.rs
@@ -283,29 +283,29 @@ pub mod standard_flags {
             /// Set for floating point, clear for integer.
             ///
             /// **Available** in OS X v10.2 and later.
-            const IS_FLOAT = 1,
+            const IS_FLOAT = 1;
             /// Set for big endian, clear for little endian.
             ///
             /// **Available** in OS X v10.2 and later.
-            const IS_BIG_ENDIAN = 2,
+            const IS_BIG_ENDIAN = 2;
             /// Set for signed integer, clear for unsigned integer.
             ///
             /// Note: This is only valid if `IS_FLOAT` is clear.
             ///
             /// **Available** in OS X v10.2 and later.
-            const IS_SIGNED_INTEGER = 4,
+            const IS_SIGNED_INTEGER = 4;
             /// Set if the sample bits occupy the entire available bits for the channel, clear if they
             /// are high- or low-aligned within the channel.
             ///
             /// **Available** in OS X v10.2 and later.
-            const IS_PACKED = 8,
+            const IS_PACKED = 8;
             /// Set if the sample bits are placed into the high bits of the channel, clear for low bit
             /// placement.
             ///
             /// Note: This is only valid if `IS_PACKED` is clear.
             ///
             /// **Available** in OS X v10.2 and later.
-            const IS_ALIGNED_HIGH = 16,
+            const IS_ALIGNED_HIGH = 16;
             /// Set if the sample for each channel are located contiguously and the channels are laid
             /// out end to end.
             ///
@@ -313,14 +313,14 @@ pub mod standard_flags {
             /// end to end.
             ///
             /// **Available** in OS X v10.2 and later.
-            const IS_NON_INTERLEAVED = 32,
+            const IS_NON_INTERLEAVED = 32;
             /// Set to indicate when a format is nonmixable.
             ///
             /// Note: that this flag is only used when interacting with the HAL's stream format
             /// information. It is **not** valid for any other use.
             ///
             /// **Available** in OS X v10.3 and later.
-            const IS_NON_MIXABLE = 64,
+            const IS_NON_MIXABLE = 64;
         }
     }
 }
@@ -341,31 +341,31 @@ pub mod linear_pcm_flags {
             /// Synonmyn for the **IS_FLOAT** **StandardFlags**.
             ///
             /// **Available** in OS X v10.0 and later.
-            const IS_FLOAT = 1,
+            const IS_FLOAT = 1;
             /// Synonmyn for the **IS_BIG_ENDIAN** **StandardFlags**.
             ///
             /// **Available** in OS X v10.0 and later.
-            const IS_BIG_ENDIAN = 2,
+            const IS_BIG_ENDIAN = 2;
             /// Synonmyn for the **IS_SIGNED_INTEGER** **StandardFlags**.
             ///
             /// **Available** in OS X v10.0 and later.
-            const IS_SIGNED_INTEGER = 4,
+            const IS_SIGNED_INTEGER = 4;
             /// Synonmyn for the **IS_PACKED** **StandardFlags**.
             ///
             /// **Available** in OS X v10.0 and later.
-            const IS_PACKED = 8,
+            const IS_PACKED = 8;
             /// Synonmyn for the **IS_ALIGNED_HIGH** **StandardFlags**.
             ///
             /// **Available** in OS X v10.0 and later.
-            const IS_ALIGNED_HIGH = 16,
+            const IS_ALIGNED_HIGH = 16;
             /// Synonmyn for the **IS_NON_INTERLEAVED** **StandardFlags**.
             ///
             /// **Available** in OS X v10.2 and later.
-            const IS_NON_INTERLEAVED = 32,
+            const IS_NON_INTERLEAVED = 32;
             /// Synonmyn for the **IS_NON_MIXABLE** **StandardFlags**.
             ///
             /// **Available** in OS X v10.3 and later.
-            const IS_NON_MIXABLE = 64,
+            const IS_NON_MIXABLE = 64;
             /// The linear PCM flags contain a 6-bit bitfield indicating that an integer format is to
             /// be interpreted as fixed point.
             ///
@@ -379,13 +379,13 @@ pub mod linear_pcm_flags {
             /// uniquely in some way.
             ///
             /// **Available** in OS X v10.6 and later.
-            const FLAGS_SAMPLE_FRACTION_SHIFT = 7,
+            const FLAGS_SAMPLE_FRACTION_SHIFT = 7;
             /// The number of fractional bits.
             ///
             /// `== (<other_flags> & FLAGS_SAMPLE_FRACTION_MASK) >> FLAGS_SAMPLE_FRACTION_SHIFT`
             ///
             /// **Available** in OS X v10.6 and later.
-            const FLAGS_SAMPLE_FRACTION_MASK = 8064,
+            const FLAGS_SAMPLE_FRACTION_MASK = 8064;
         }
     }
 }
@@ -406,13 +406,13 @@ pub mod apple_lossless_flags {
         /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
         pub struct AppleLosslessFlags: u32 {
             /// Sourced from 16 bit native endian signed integer data.
-            const BIT_16_SOURCE_DATA = 1,
+            const BIT_16_SOURCE_DATA = 1;
             /// Sourced from 20 bit native endian signed integer data aligned high in 24 bits.
-            const BIT_20_SOURCE_DATA = 2,
+            const BIT_20_SOURCE_DATA = 2;
             /// Sourced from 24 bit native endian signed integer data.
-            const BIT_24_SOURCE_DATA = 3,
+            const BIT_24_SOURCE_DATA = 3;
             /// Sourced from 32 bit native endian signed integer data.
-            const BIT_32_SOURCE_DATA = 4,
+            const BIT_32_SOURCE_DATA = 4;
         }
     }
 }
@@ -485,15 +485,15 @@ pub mod audio_time_stamp_flags {
         /// Original Documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Time_Stamp_Flags).
         pub struct AudioTimeStampFlags: u32 {
             /// The sample frame time is valid.
-            const SAMPLE_TIME_VALID = 1,
+            const SAMPLE_TIME_VALID = 1;
             /// The host time is valid.
-            const HOST_TIME_VALID = 2,
+            const HOST_TIME_VALID = 2;
             /// The rate scalar is valid.
-            const RATE_SCALAR_VALID = 4,
+            const RATE_SCALAR_VALID = 4;
             /// The world clock time is valid.
-            const WORLD_CLOCK_TIME_VALID = 8,
+            const WORLD_CLOCK_TIME_VALID = 8;
             /// The SMPTE time is valid.
-            const SMPTE_TIME_VALID = 16,
+            const SMPTE_TIME_VALID = 16;
         }
     }
 }

--- a/src/audio_unit/audio_format.rs
+++ b/src/audio_unit/audio_format.rs
@@ -279,7 +279,7 @@ pub mod standard_flags {
         /// the **AudioFormat** type.
         /// 
         /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        pub flags StandardFlags: u32 {
+        pub struct StandardFlags: u32 {
             /// Set for floating point, clear for integer.
             ///
             /// **Available** in OS X v10.2 and later.
@@ -337,7 +337,7 @@ pub mod linear_pcm_flags {
         /// the **AudioFormat** type.
         ///
         /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        pub flags LinearPCMFlags: u32 {
+        pub struct LinearPCMFlags: u32 {
             /// Synonmyn for the **IS_FLOAT** **StandardFlags**.
             ///
             /// **Available** in OS X v10.0 and later.
@@ -404,7 +404,7 @@ pub mod apple_lossless_flags {
         /// the **AudioFormat** type.
         ///
         /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
-        pub flags AppleLosslessFlags: u32 {
+        pub struct AppleLosslessFlags: u32 {
             /// Sourced from 16 bit native endian signed integer data.
             const BIT_16_SOURCE_DATA = 1,
             /// Sourced from 20 bit native endian signed integer data aligned high in 24 bits.
@@ -483,7 +483,7 @@ pub mod audio_time_stamp_flags {
         /// **Available** in OS X v10.0 and later.
         ///
         /// Original Documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Time_Stamp_Flags).
-        pub flags AudioTimeStampFlags: u32 {
+        pub struct AudioTimeStampFlags: u32 {
             /// The sample frame time is valid.
             const SAMPLE_TIME_VALID = 1,
             /// The host time is valid.

--- a/src/audio_unit/render_callback.rs
+++ b/src/audio_unit/render_callback.rs
@@ -231,20 +231,20 @@ pub mod action_flags {
             /// before the render operation is performed.
             ///
             /// **Available** in OS X v10.0 and later.
-            const PRE_RENDER = au::kAudioUnitRenderAction_PreRender,
+            const PRE_RENDER = au::kAudioUnitRenderAction_PreRender;
             /// Called on a render notification Proc, which is called either before or after the
             /// render operation of the audio unit. If this flag is set, the proc is being called
             /// after the render operation is completed.
             ///
             /// **Available** in OS X v10.0 and later.
-            const POST_RENDER = au::kAudioUnitRenderAction_PostRender,
+            const POST_RENDER = au::kAudioUnitRenderAction_PostRender;
             /// This flag can be set in a render input callback (or in the audio unit's render
             /// operation itself) and is used to indicate that the render buffer contains only
             /// silence. It can then be used by the caller as a hint to whether the buffer needs to
             /// be processed or not.
             ///
             /// **Available** in OS X v10.2 and later.
-            const OUTPUT_IS_SILENCE = au::kAudioUnitRenderAction_OutputIsSilence,
+            const OUTPUT_IS_SILENCE = au::kAudioUnitRenderAction_OutputIsSilence;
             /// This is used with offline audio units (of type 'auol'). It is used when an offline
             /// unit is being preflighted, which is performed prior to when the actual offline
             /// rendering actions are performed. It is used for those cases where the offline
@@ -253,32 +253,32 @@ pub mod action_flags {
             /// normalization).
             ///
             /// **Available** in OS X v10.3 and later.
-            const OFFLINE_PREFLIGHT = au::kAudioOfflineUnitRenderAction_Preflight,
+            const OFFLINE_PREFLIGHT = au::kAudioOfflineUnitRenderAction_Preflight;
             /// Once an offline unit has been successfully preflighted, it is then put into its
             /// render mode. This flag is set to indicate to the audio unit that it is now in that
             /// state and that it should perform processing on the input data.
             ///
             /// **Available** in OS X v10.3 and later.
-            const OFFLINE_RENDER = au::kAudioOfflineUnitRenderAction_Render,
+            const OFFLINE_RENDER = au::kAudioOfflineUnitRenderAction_Render;
             /// This flag is set when an offline unit has completed either its preflight or
             /// performed render operation.
             ///
             /// **Available** in OS X v10.3 and later.
-            const OFFLINE_COMPLETE = au::kAudioOfflineUnitRenderAction_Complete,
+            const OFFLINE_COMPLETE = au::kAudioOfflineUnitRenderAction_Complete;
             /// If this flag is set on the post-render call an error was returned by the audio
             /// unit's render operation. In this case, the error can be retrieved through the
             /// `lastRenderError` property and the audio data in `ioData` handed to the post-render
             /// notification will be invalid.
             ///
             /// **Available** in OS X v10.5 and later.
-            const POST_RENDER_ERROR = au::kAudioUnitRenderAction_PostRenderError,
+            const POST_RENDER_ERROR = au::kAudioUnitRenderAction_PostRenderError;
             /// If this flag is set, then checks that are done on the arguments provided to render
             /// are not performed. This can be useful to use to save computation time in situations
             /// where you are sure you are providing the correct arguments and structures to the
             /// various render calls.
             ///
             /// **Available** in OS X v10.7 and later.
-            const DO_NOT_CHECK_RENDER_ARGS = au::kAudioUnitRenderAction_DoNotCheckRenderArgs,
+            const DO_NOT_CHECK_RENDER_ARGS = au::kAudioUnitRenderAction_DoNotCheckRenderArgs;
         }
     }
 

--- a/src/audio_unit/render_callback.rs
+++ b/src/audio_unit/render_callback.rs
@@ -225,7 +225,7 @@ pub mod action_flags {
     use bindings::audio_unit as au;
 
     bitflags!{
-        pub flags ActionFlags: u32 {
+        pub struct ActionFlags: u32 {
             /// Called on a render notification Proc, which is called either before or after the
             /// render operation of the audio unit. If this flag is set, the proc is being called
             /// before the render operation is performed.

--- a/src/audio_unit/sample_format.rs
+++ b/src/audio_unit/sample_format.rs
@@ -1,4 +1,4 @@
-use super::audio_format::{self, linear_pcm_flags};
+use super::audio_format::{self, LinearPcmFlags};
 
 
 /// Dynamic representation of audio data sample format.
@@ -12,9 +12,9 @@ pub enum SampleFormat {
 
 impl SampleFormat {
 
-    pub fn does_match_flags(&self, flags: audio_format::LinearPCMFlags) -> bool {
-        let is_float = flags.contains(linear_pcm_flags::IS_FLOAT);
-        let is_signed_integer = flags.contains(linear_pcm_flags::IS_SIGNED_INTEGER);
+    pub fn does_match_flags(&self, flags: audio_format::LinearPcmFlags) -> bool {
+        let is_float = flags.contains(LinearPcmFlags::IS_FLOAT);
+        let is_signed_integer = flags.contains(LinearPcmFlags::IS_SIGNED_INTEGER);
         match *self {
             SampleFormat::F32 => is_float && !is_signed_integer,
             SampleFormat::I32 |
@@ -23,10 +23,10 @@ impl SampleFormat {
         }
     }
 
-    pub fn from_flags_and_bytes_per_frame(flags: audio_format::LinearPCMFlags,
+    pub fn from_flags_and_bytes_per_frame(flags: audio_format::LinearPcmFlags,
                                           bytes_per_frame: u32) -> Option<Self>
     {
-        Some(if flags.contains(linear_pcm_flags::IS_FLOAT) {
+        Some(if flags.contains(LinearPcmFlags::IS_FLOAT) {
             SampleFormat::F32
         } else {
             // TODO: Check whether or not we need to consider unsigned ints and `IS_PACKED`.

--- a/src/audio_unit/stream_format.rs
+++ b/src/audio_unit/stream_format.rs
@@ -46,7 +46,7 @@ pub struct StreamFormat {
     /// battery drain when processing audio. iOS provides a Converter audio unit and inclues the
     /// interfaces from Audio Converter Services (TODO: look into exposing this).
     pub sample_format: SampleFormat,
-    pub flags: super::audio_format::LinearPCMFlags,
+    pub flags: super::audio_format::LinearPcmFlags,
     pub channels_per_frame: u32,
 }
 


### PR DESCRIPTION
See #54.

Also updates to bitflags v1.0 which moves the flags from modules to associated types on their respective flag types.

`LinearPCMFlags` was renamed to `LinearPcmFlags` in order to follow rust's camel-case abbreviation conventions more closely.

cc @matwork I just realised that #54 is a breaking change due to rust's exhaustive matching so I've bumped this to 0.7 instead :+1: