### PR TITLE
Update to coreaudio-sys 0.2. Rename reexport from bindings to sys. Publish 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-rs"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]
@@ -14,5 +14,4 @@ name = "coreaudio"
 
 [dependencies]
 bitflags = "1.0"
-coreaudio-sys = "0.1"
-libc = "0.2"
+coreaudio-sys = "0.2"

--- a/src/audio_unit/audio_format.rs
+++ b/src/audio_unit/audio_format.rs
@@ -3,8 +3,7 @@
 //! See the Core Audio Data Types Reference
 //! [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Data_Format_Identifiers) for more info.
 
-
-use libc;
+use std::os::raw::c_uint;
 
 /// A type-safe representation of both the `AudioFormatId` and their associated flags.
 #[derive(Copy, Clone, Debug)]
@@ -175,7 +174,7 @@ pub enum AudioFormat {
 impl AudioFormat {
 
     /// Convert from the FFI C format and flags to a typesafe Rust enum representation.
-    pub fn from_format_and_flag(format: libc::c_uint, flag: Option<u32>) -> Option<AudioFormat> {
+    pub fn from_format_and_flag(format: c_uint, flag: Option<u32>) -> Option<AudioFormat> {
         match (format, flag) {
             (1819304813, Some(i)) => Some(AudioFormat::LinearPCM(LinearPcmFlags::from_bits_truncate(i))),
             (1633889587, _)       => Some(AudioFormat::AC3),
@@ -218,7 +217,7 @@ impl AudioFormat {
     }
 
     /// Convert from the Rust enum to the C format and flag.
-    pub fn to_format_and_flag(&self) -> (libc::c_uint, Option<u32>) {
+    pub fn to_format_and_flag(&self) -> (c_uint, Option<u32>) {
         match *self {
             AudioFormat::LinearPCM(flag)      => (1819304813, Some(flag.bits())),
             AudioFormat::AC3                  => (1633889587, None),

--- a/src/audio_unit/stream_format.rs
+++ b/src/audio_unit/stream_format.rs
@@ -2,10 +2,10 @@
 //!
 //! Find the original `AudioStreamBasicDescription` reference [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/c/tdef/AudioStreamBasicDescription).
 
-use bindings::audio_unit as au;
 use error::{self, Error};
 use super::audio_format::AudioFormat;
 use super::SampleFormat;
+use sys;
 
 /// A representation of the AudioStreamBasicDescription specifically for use with the AudioUnit API.
 ///
@@ -66,10 +66,10 @@ impl StreamFormat {
     ///
     /// Returns an `Error` if the sample format type kkkkkkkkkkkkkkkkkkkkkk
     #[allow(non_snake_case)]
-    pub fn from_asbd(asbd: au::AudioStreamBasicDescription) -> Result<StreamFormat, Error> {
+    pub fn from_asbd(asbd: sys::AudioStreamBasicDescription) -> Result<StreamFormat, Error> {
         const NOT_SUPPORTED: Error = Error::AudioUnit(error::audio_unit::Error::FormatNotSupported);
 
-        let au::Struct_AudioStreamBasicDescription {
+        let sys::AudioStreamBasicDescription {
             mSampleRate,
             mFormatID,
             mFormatFlags,
@@ -99,7 +99,7 @@ impl StreamFormat {
     }
 
     /// Convert a StreamFormat into an AudioStreamBasicDescription.
-    pub fn to_asbd(self) -> au::AudioStreamBasicDescription {
+    pub fn to_asbd(self) -> sys::AudioStreamBasicDescription {
         let StreamFormat {
             sample_rate,
             flags,
@@ -116,7 +116,7 @@ impl StreamFormat {
         let bytes_per_packet = bytes_per_frame * FRAMES_PER_PACKET;
         let bits_per_channel = bytes_per_frame * 8;
 
-        au::AudioStreamBasicDescription {
+        sys::AudioStreamBasicDescription {
             mSampleRate: sample_rate,
             mFormatID: format,
             mFormatFlags: flag,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
 //! This module is an attempt at rustifying the OSStatus result.
 
-use bindings::audio_unit::OSStatus;
 pub use self::audio::Error as AudioError;
 pub use self::audio_codec::Error as AudioCodecError;
 pub use self::audio_format::Error as AudioFormatError;
 pub use self::audio_unit::Error as AudioUnitError;
+use sys::OSStatus;
 
 pub mod audio {
-    use bindings::audio_unit::OSStatus;
+    use sys::OSStatus;
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
@@ -68,7 +68,7 @@ pub mod audio {
 
 
 pub mod audio_codec {
-    use bindings::audio_unit::OSStatus;
+    use sys::OSStatus;
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
@@ -129,7 +129,7 @@ pub mod audio_codec {
 
 
 pub mod audio_format {
-    use bindings::audio_unit::OSStatus;
+    use sys::OSStatus;
 
     // TODO: Finish implementing these values.
     #[derive(Copy, Clone, Debug)]
@@ -182,7 +182,7 @@ pub mod audio_format {
 
 
 pub mod audio_unit {
-    use bindings::audio_unit::OSStatus;
+    use sys::OSStatus;
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,7 @@
 //! eventually we'd like to cover at least the majority of the C API.
 
 #[macro_use] extern crate bitflags;
-pub extern crate coreaudio_sys as bindings;
-
-extern crate libc;
+pub extern crate coreaudio_sys as sys;
 
 pub use error::Error;
 


### PR DESCRIPTION
See RustAudio/coreaudio-sys#4 for more details.

Also add's some missing `Scope` variants and fixes their enumeration order.

Removes the dependency on libc in favour of `std::os::raw`.

Publish 0.8 for the breaking change.