### PR TITLE
Add optional features to match those offered by coreaudio-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-rs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]
@@ -12,6 +12,14 @@ homepage = "https://github.com/RustAudio/coreaudio-rs"
 [lib]
 name = "coreaudio"
 
+[features]
+default = ["audio_toolbox", "audio_unit", "core_audio", "open_al", "core_midi"]
+audio_toolbox = ["coreaudio-sys/audio_toolbox"]
+audio_unit = ["coreaudio-sys/audio_unit"]
+core_audio = ["coreaudio-sys/core_audio"]
+open_al = ["coreaudio-sys/open_al"]
+core_midi = ["coreaudio-sys/core_midi"]
+
 [dependencies]
 bitflags = "1.0"
-coreaudio-sys = "0.2"
+coreaudio-sys = { version = "0.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,6 @@ pub extern crate coreaudio_sys as sys;
 
 pub use error::Error;
 
+#[cfg(feature = "audio_unit")]
 pub mod audio_unit;
 pub mod error;


### PR DESCRIPTION
An optional feaure per framework is now provided for more granular
control over the framework linking.

Note that at last one feature must be enabled at all times or
coreaudio-sys and coreaudio-rs will fail to compile.