### PR TITLE
 Add support for AudioUnits with input streams 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-rs"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -33,7 +33,7 @@ fn run() -> Result<(), coreaudio::Error> {
     // Construct an Output audio unit that delivers audio to the default output device.
     let mut audio_unit = try!(AudioUnit::new(IOType::DefaultOutput));
 
-    let stream_format = try!(audio_unit.stream_format());
+    let stream_format = try!(audio_unit.output_stream_format());
     println!("{:#?}", &stream_format);
 
     // For this example, our sine wave expects `f32` data.


### PR DESCRIPTION
An AudioUnit that is setup for input streams can now receive data by
calling `set_input_callback`.

This also updates some of the other `AudioUnit` methods to no longer
assume output streams.

Publish **0.9** with breaking changes related to input support.