### PR TITLE
Fix bug where input stream buffer was created using output stream format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-rs"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]

--- a/src/audio_unit/render_callback.rs
+++ b/src/audio_unit/render_callback.rs
@@ -471,7 +471,7 @@ impl AudioUnit {
         // First, we'll retrieve the stream format so that we can ensure that the given callback
         // format matches the audio unit's format.
         let id = sys::kAudioUnitProperty_StreamFormat;
-        let asbd = self.get_property(id, Scope::Input, Element::Output)?;
+        let asbd = self.get_property(id, Scope::Input, Element::Input)?;
         let stream_format = super::StreamFormat::from_asbd(asbd)?;
 
         // If the stream format does not match, return an error indicating this.


### PR DESCRIPTION
This happened to work in the past as in many cases the input stream will
have less than or equal to the same number of channels as the output
stream.

Will publish this as 0.9.1.