### PR TITLE
Added initial changes for iOS support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ env:
 before_script:
 - rustc --version
 - cargo --version
+- rustup target add aarch64-apple-ios
 script:
 - cargo build --verbose
 - cargo test --verbose
 - cargo doc --verbose
+- cargo build --target aarch64-apple-ios
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ core_midi = ["coreaudio-sys/core_midi"]
 
 [dependencies]
 bitflags = "1.0"
-coreaudio-sys = { version = "0.2", default-features = false }
+coreaudio-sys = { git = "https://github.com/simlay/coreaudio-sys", branch = "add-ios-support", default-features = false }

--- a/src/audio_unit/mod.rs
+++ b/src/audio_unit/mod.rs
@@ -89,7 +89,7 @@ struct InputCallback {
 
 
 macro_rules! try_os_status {
-    ($expr:expr) => (try!(Error::from_os_status($expr)))
+    ($expr:expr) => (Error::from_os_status($expr)?)
 }
 
 
@@ -267,7 +267,7 @@ impl AudioUnit {
     /// Return the current Stream Format for the AudioUnit.
     pub fn stream_format(&self, scope: Scope) -> Result<StreamFormat, Error> {
         let id = sys::kAudioUnitProperty_StreamFormat;
-        let asbd = try!(self.get_property(id, scope, Element::Output));
+        let asbd = self.get_property(id, scope, Element::Output)?;
         StreamFormat::from_asbd(asbd)
     }
 


### PR DESCRIPTION
The only real change here I think is the usage of:
`kAudioSessionProperty_CurrentHardwareIOBufferDuration` rather than `kAudioDevicePropertyBufferFrameSize` which I found at https://stackoverflow.com/questions/13157523/kaudiodevicepropertybufferframesize-replacement-for-ios

Most of these changes are conditional compilation things and mapping the names of the iOS version of the bindings.

This is obviously dependent on https://github.com/RustAudio/coreaudio-sys/pull/33