### PR TITLE
Fix math for computing bits_per_channel

### DIFF
--- a/src/audio_unit/stream_format.rs
+++ b/src/audio_unit/stream_format.rs
@@ -18,7 +18,7 @@ use sys;
 /// `bytes_per_packet` = size_of::<S>()
 /// `bytes_per_frame` = size_of::<S>()
 /// `frames_per_packet` = 1
-/// `bits_per_channel` = size_of::<S>() * 8
+/// `bits_per_channel` = size_of::<S>() / channels_per_frame * 8
 ///
 /// > A *packet* is a collection of one or more contiguous frames. In linear PCM audio, a packet is
 /// always a single frame.
@@ -114,7 +114,7 @@ impl StreamFormat {
         let bytes_per_frame = sample_format.size_in_bytes() as u32;
         const FRAMES_PER_PACKET: u32 = 1;
         let bytes_per_packet = bytes_per_frame * FRAMES_PER_PACKET;
-        let bits_per_channel = bytes_per_frame * 8;
+        let bits_per_channel = bytes_per_frame / channels_per_frame * 8;
 
         sys::AudioStreamBasicDescription {
             mSampleRate: sample_rate,


### PR DESCRIPTION
Hello! Thank you for making this lovely crate, it has been a great help to me in learning CoreAudio. This is also my first ever pull request, but it's a simple one.

This fix should solve this issue in the comments of [`render_callback`](https://github.com/RustAudio/coreaudio-rs/blob/08c8b797f3aba1e2b8a12937067b6bd2dc80db4c/src/audio_unit/render_callback.rs#L80)
> // TODO: When testing with the `HalOutput` audio unit it seemed not to allow interleaved data.
    // Even though the `IS_NON_INTERLEAVED` flag was not set, the audio unit continues to deliver
    // the audio as non-interleaved samples anyway. Investigate this, as it might not even be
    // possible to use this type with audio units! 

I got interleaved channels on `HalOutput` within one buffer working on my end with this small change. Hope it helps!