### PR TITLE
Fix iOS compilation error and add macOS + iOS feedback example applications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   - LD_LIBRARY_PATH: /usr/local/lib
   global:
   - secure: URNNlOqxnfwWDC/w4PDTCswqe9ccnkIqDwfQecppfEui4KhpYXfrG9gx3xupWzWMfX+NPEcXtiyWA4CuUYaHbWWINLeLQUk650AFEqaRSiTpeh45Y9nh3dHT4fFDz4OeNfayNBBKL0kx5YwrugoeQggIgnF2KEcIHMF0+BbTtAM=
+install:
+- rustup target add aarch64-apple-ios x86_64-apple-ios
 before_script:
 - rustc --version
 - cargo --version
@@ -20,6 +22,8 @@ script:
 - cargo build --verbose
 - cargo test --verbose
 - cargo doc --verbose
+- cargo build --verbose --target aarch64-apple-ios
+- cargo build --verbose --target x86_64-apple-ios
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -1,0 +1,214 @@
+//! A basic input + output stream example, copying the mic input stream to the default output stream
+
+extern crate coreaudio;
+
+use std::collections::VecDeque;
+use std::mem;
+use std::ptr::null;
+use std::sync::{Arc, Mutex};
+
+use coreaudio::audio_unit::audio_format::LinearPcmFlags;
+use coreaudio::audio_unit::render_callback::{self, data};
+use coreaudio::audio_unit::{AudioUnit, Element, SampleFormat, Scope, StreamFormat};
+use coreaudio::sys::*;
+
+const SAMPLE_RATE: f64 = 44100.0;
+
+type S = f32; const SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
+// type S = i32; const SAMPLE_FORMAT: SampleFormat = SampleFormat::I32;
+// type S = i16; const SAMPLE_FORMAT: SampleFormat = SampleFormat::I16;
+// type S = i8; const SAMPLE_FORMAT: SampleFormat = SampleFormat::I8;
+
+fn main() -> Result<(), coreaudio::Error> {
+    let mut input_audio_unit = audio_unit_from_device(default_input_device().unwrap(), true)?;
+    let mut output_audio_unit = audio_unit_from_device(default_output_device().unwrap(), false)?;
+
+    let format_flag = match SAMPLE_FORMAT {
+        SampleFormat::F32 => LinearPcmFlags::IS_FLOAT,
+        SampleFormat::I32 | SampleFormat::I16 | SampleFormat::I8 => LinearPcmFlags::IS_SIGNED_INTEGER,
+    };
+
+    // Using IS_NON_INTERLEAVED everywhere because data::Interleaved is commented out / not implemented
+    let in_stream_format = StreamFormat {
+        sample_rate: SAMPLE_RATE,
+        sample_format: SAMPLE_FORMAT,
+        flags: format_flag | LinearPcmFlags::IS_PACKED | LinearPcmFlags::IS_NON_INTERLEAVED,
+        // audio_unit.set_input_callback is hardcoded to 1 buffer, and when using non_interleaved
+        // we are forced to 1 channel
+        channels_per_frame: 1,
+    };
+
+    let out_stream_format = StreamFormat {
+        sample_rate: SAMPLE_RATE,
+        sample_format: SAMPLE_FORMAT,
+        flags: format_flag | LinearPcmFlags::IS_PACKED | LinearPcmFlags::IS_NON_INTERLEAVED,
+        // you can change this to 1
+        channels_per_frame: 2,
+    };
+
+    println!("input={:#?}", &in_stream_format);
+    println!("output={:#?}", &out_stream_format);
+    println!("input_asbd={:#?}", &in_stream_format.to_asbd());
+    println!("output_asbd={:#?}", &out_stream_format.to_asbd());
+
+    let id = kAudioUnitProperty_StreamFormat;
+    let asbd = in_stream_format.to_asbd();
+    input_audio_unit.set_property(id, Scope::Output, Element::Input, Some(&asbd))?;
+
+    let asbd = out_stream_format.to_asbd();
+    output_audio_unit.set_property(id, Scope::Input, Element::Output, Some(&asbd))?;
+
+    let buffer_left = Arc::new(Mutex::new(VecDeque::<S>::new()));
+    let producer_left = buffer_left.clone();
+    let consumer_left = buffer_left.clone();
+    let buffer_right = Arc::new(Mutex::new(VecDeque::<S>::new()));
+    let producer_right = buffer_right.clone();
+    let consumer_right = buffer_right.clone();
+
+    // seed roughly 1 second of data to create a delay in the feedback loop for easier testing
+    for buffer in vec![buffer_left, buffer_right] {
+        let mut buffer = buffer.lock().unwrap();
+        for _ in 0..(out_stream_format.sample_rate as i32) {
+            buffer.push_back(0 as S);
+        }
+    }
+
+    type Args = render_callback::Args<data::NonInterleaved<S>>;
+
+    input_audio_unit.set_input_callback(move |args| {
+        let Args {
+            num_frames,
+            mut data,
+            ..
+        } = args;
+        let buffer_left = producer_left.lock().unwrap();
+        let buffer_right = producer_right.lock().unwrap();
+        let mut buffers = vec![buffer_left, buffer_right];
+        for i in 0..num_frames {
+            for (ch, channel) in data.channels_mut().enumerate() {
+                let value: S = channel[i];
+                buffers[ch].push_back(value);
+            }
+        }
+        Ok(())
+    })?;
+    input_audio_unit.start()?;
+
+    output_audio_unit.set_render_callback(move |args: Args| {
+        let Args {
+            num_frames,
+            mut data,
+            ..
+        } = args;
+
+        let buffer_left = consumer_left.lock().unwrap();
+        let buffer_right = consumer_right.lock().unwrap();
+        let mut buffers = vec![buffer_left, buffer_right];
+        for i in 0..num_frames {
+            // Default other channels to copy value from first channel as a fallback
+            let zero: S = 0 as S;
+            let f: S = *buffers[0].front().unwrap_or(&zero);
+            for (ch, channel) in data.channels_mut().enumerate() {
+                let sample: S = buffers[ch].pop_front().unwrap_or(f);
+                channel[i] = sample;
+            }
+        }
+        Ok(())
+    })?;
+    output_audio_unit.start()?;
+
+    std::thread::sleep(std::time::Duration::from_millis(100000));
+
+    Ok(())
+}
+
+/// Copied from cpal
+pub fn default_input_device() -> Option<AudioDeviceID> {
+    let property_address = AudioObjectPropertyAddress {
+        mSelector: kAudioHardwarePropertyDefaultInputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+
+    let audio_device_id: AudioDeviceID = 0;
+    let data_size = mem::size_of::<AudioDeviceID>();
+    let status = unsafe {
+        AudioObjectGetPropertyData(
+            kAudioObjectSystemObject,
+            &property_address as *const _,
+            0,
+            null(),
+            &data_size as *const _ as *mut _,
+            &audio_device_id as *const _ as *mut _,
+        )
+    };
+    if status != kAudioHardwareNoError as i32 {
+        return None;
+    }
+
+    Some(audio_device_id)
+}
+
+/// Copied from cpal
+pub fn default_output_device() -> Option<AudioDeviceID> {
+    let property_address = AudioObjectPropertyAddress {
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+
+    let audio_device_id: AudioDeviceID = 0;
+    let data_size = mem::size_of::<AudioDeviceID>();
+    let status = unsafe {
+        AudioObjectGetPropertyData(
+            kAudioObjectSystemObject,
+            &property_address as *const _,
+            0,
+            null(),
+            &data_size as *const _ as *mut _,
+            &audio_device_id as *const _ as *mut _,
+        )
+    };
+    if status != kAudioHardwareNoError as i32 {
+        return None;
+    }
+
+    Some(audio_device_id)
+}
+
+/// Copied from cpal
+fn audio_unit_from_device(
+    device_id: AudioDeviceID,
+    input: bool,
+) -> Result<AudioUnit, coreaudio::Error> {
+    let mut audio_unit = AudioUnit::new(coreaudio::audio_unit::IOType::HalOutput)?;
+
+    if input {
+        // Enable input processing.
+        let enable_input = 1u32;
+        audio_unit.set_property(
+            kAudioOutputUnitProperty_EnableIO,
+            Scope::Input,
+            Element::Input,
+            Some(&enable_input),
+        )?;
+
+        // Disable output processing.
+        let disable_output = 0u32;
+        audio_unit.set_property(
+            kAudioOutputUnitProperty_EnableIO,
+            Scope::Output,
+            Element::Output,
+            Some(&disable_output),
+        )?;
+    }
+
+    audio_unit.set_property(
+        kAudioOutputUnitProperty_CurrentDevice,
+        Scope::Global,
+        Element::Output,
+        Some(&device_id),
+    )?;
+
+    Ok(audio_unit)
+}

--- a/examples/ios/Cargo.toml
+++ b/examples/ios/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "coreaudio-ios-example"
+version = "0.1.0"
+authors = ["Michael Hills <mhills@gmail.com>"]
+edition = "2018"
+
+[lib]
+name = "coreaudio_ios_example"
+crate-type = ["staticlib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+coreaudio-rs = { path = "../.." }
+

--- a/examples/ios/build_rust_deps.sh
+++ b/examples/ios/build_rust_deps.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+PATH=$PATH:$HOME/.cargo/bin
+
+# If you want your build to run faster, add a "--targets x86_64-apple-ios" for just using the ios simulator.
+if [ -n ${IOS_TARGETS} ]; then
+    cargo lipo --targets ${IOS_TARGETS}
+else
+    cargo lipo
+fi

--- a/examples/ios/coreaudio-ios-example.xcodeproj/project.pbxproj
+++ b/examples/ios/coreaudio-ios-example.xcodeproj/project.pbxproj
@@ -1,0 +1,429 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		57AB5AF3252767460040DE8C /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57AB5AF2252767460040DE8C /* AVFoundation.framework */; };
+		57AB5B07252769700040DE8C /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 57AB5AFE252769700040DE8C /* ViewController.m */; };
+		57AB5B08252769700040DE8C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 57AB5AFF252769700040DE8C /* LaunchScreen.storyboard */; };
+		57AB5B09252769700040DE8C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 57AB5B01252769700040DE8C /* Main.storyboard */; };
+		57AB5B0A252769700040DE8C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 57AB5B03252769700040DE8C /* main.m */; };
+		57AB5B0B252769700040DE8C /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 57AB5B04252769700040DE8C /* AppDelegate.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		57AB5AEE252766820040DE8C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 57AB5AC2252762C00040DE8C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57AB5AE9252766240040DE8C;
+			remoteInfo = cargo_ios;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		57AB5ACA252762C10040DE8C /* coreaudio-ios-example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "coreaudio-ios-example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57AB5AF2252767460040DE8C /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		57AB5AFD252769700040DE8C /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		57AB5AFE252769700040DE8C /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		57AB5B00252769700040DE8C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		57AB5B02252769700040DE8C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		57AB5B03252769700040DE8C /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		57AB5B04252769700040DE8C /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		57AB5B05252769700040DE8C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		57AB5B06252769700040DE8C /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57AB5AC7252762C10040DE8C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57AB5AF3252767460040DE8C /* AVFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57AB5AC1252762C00040DE8C = {
+			isa = PBXGroup;
+			children = (
+				57AB5AFC252769700040DE8C /* ios-src */,
+				57AB5ACB252762C10040DE8C /* Products */,
+				57AB5AF1252767460040DE8C /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		57AB5ACB252762C10040DE8C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57AB5ACA252762C10040DE8C /* coreaudio-ios-example.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57AB5AF1252767460040DE8C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				57AB5AF2252767460040DE8C /* AVFoundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		57AB5AFC252769700040DE8C /* ios-src */ = {
+			isa = PBXGroup;
+			children = (
+				57AB5AFD252769700040DE8C /* AppDelegate.h */,
+				57AB5B04252769700040DE8C /* AppDelegate.m */,
+				57AB5B06252769700040DE8C /* ViewController.h */,
+				57AB5AFE252769700040DE8C /* ViewController.m */,
+				57AB5AFF252769700040DE8C /* LaunchScreen.storyboard */,
+				57AB5B01252769700040DE8C /* Main.storyboard */,
+				57AB5B05252769700040DE8C /* Info.plist */,
+				57AB5B03252769700040DE8C /* main.m */,
+			);
+			path = "ios-src";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXLegacyTarget section */
+		57AB5AE9252766240040DE8C /* cargo_ios */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = build_rust_deps.sh;
+			buildConfigurationList = 57AB5AEA252766240040DE8C /* Build configuration list for PBXLegacyTarget "cargo_ios" */;
+			buildPhases = (
+			);
+			buildToolPath = /bin/sh;
+			buildWorkingDirectory = .;
+			dependencies = (
+			);
+			name = cargo_ios;
+			passBuildSettingsInEnvironment = 1;
+			productName = cargo_ios;
+		};
+/* End PBXLegacyTarget section */
+
+/* Begin PBXNativeTarget section */
+		57AB5AC9252762C10040DE8C /* coreaudio-ios-example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57AB5AE3252762C30040DE8C /* Build configuration list for PBXNativeTarget "coreaudio-ios-example" */;
+			buildPhases = (
+				57AB5AC6252762C10040DE8C /* Sources */,
+				57AB5AC7252762C10040DE8C /* Frameworks */,
+				57AB5AC8252762C10040DE8C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				57AB5AEF252766820040DE8C /* PBXTargetDependency */,
+			);
+			name = "coreaudio-ios-example";
+			productName = "coreaudio-ios-example";
+			productReference = 57AB5ACA252762C10040DE8C /* coreaudio-ios-example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57AB5AC2252762C00040DE8C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+					57AB5AC9252762C10040DE8C = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+					57AB5AE9252766240040DE8C = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+				};
+			};
+			buildConfigurationList = 57AB5AC5252762C00040DE8C /* Build configuration list for PBXProject "coreaudio-ios-example" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 57AB5AC1252762C00040DE8C;
+			productRefGroup = 57AB5ACB252762C10040DE8C /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57AB5AC9252762C10040DE8C /* coreaudio-ios-example */,
+				57AB5AE9252766240040DE8C /* cargo_ios */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		57AB5AC8252762C10040DE8C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57AB5B09252769700040DE8C /* Main.storyboard in Resources */,
+				57AB5B08252769700040DE8C /* LaunchScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57AB5AC6252762C10040DE8C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57AB5B0A252769700040DE8C /* main.m in Sources */,
+				57AB5B0B252769700040DE8C /* AppDelegate.m in Sources */,
+				57AB5B07252769700040DE8C /* ViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		57AB5AEF252766820040DE8C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57AB5AE9252766240040DE8C /* cargo_ios */;
+			targetProxy = 57AB5AEE252766820040DE8C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		57AB5AFF252769700040DE8C /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				57AB5B00252769700040DE8C /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		57AB5B01252769700040DE8C /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				57AB5B02252769700040DE8C /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		57AB5AE1252762C30040DE8C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		57AB5AE2252762C30040DE8C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		57AB5AE4252762C30040DE8C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "ios-src/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = target/universal/debug;
+				OTHER_LDFLAGS = "-lcoreaudio_ios_example";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "coreaudio-rs.coreaudio-ios-example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		57AB5AE5252762C30040DE8C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "ios-src/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = target/universal/release;
+				OTHER_LDFLAGS = "-lcoreaudio_ios_example";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "coreaudio-rs.coreaudio-ios-example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		57AB5AEB252766240040DE8C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEBUGGING_SYMBOLS = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		57AB5AEC252766240040DE8C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57AB5AC5252762C00040DE8C /* Build configuration list for PBXProject "coreaudio-ios-example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57AB5AE1252762C30040DE8C /* Debug */,
+				57AB5AE2252762C30040DE8C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57AB5AE3252762C30040DE8C /* Build configuration list for PBXNativeTarget "coreaudio-ios-example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57AB5AE4252762C30040DE8C /* Debug */,
+				57AB5AE5252762C30040DE8C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57AB5AEA252766240040DE8C /* Build configuration list for PBXLegacyTarget "cargo_ios" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57AB5AEB252766240040DE8C /* Debug */,
+				57AB5AEC252766240040DE8C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57AB5AC2252762C00040DE8C /* Project object */;
+}

--- a/examples/ios/coreaudio-ios-example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/ios/coreaudio-ios-example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/ios/coreaudio-ios-example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/ios/coreaudio-ios-example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ios/ios-src/AppDelegate.h
+++ b/examples/ios/ios-src/AppDelegate.h
@@ -1,0 +1,15 @@
+//
+//  AppDelegate.h
+//  coreaudio-ios-example
+//
+//  Created by Michael Hills on 2/10/20.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end
+

--- a/examples/ios/ios-src/AppDelegate.m
+++ b/examples/ios/ios-src/AppDelegate.m
@@ -1,0 +1,48 @@
+//
+//  AppDelegate.m
+//  coreaudio-ios-example
+//
+//  Created by Michael Hills on 2/10/20.
+//
+
+#import "AppDelegate.h"
+@import AVFoundation;
+
+void rust_ios_main(void);
+
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    
+    NSError *error;
+    BOOL success;
+    
+    // It is necessary to access the sharedInstance so that calls to AudioSessionGetProperty
+    // will work.
+    AVAudioSession *session = AVAudioSession.sharedInstance;
+    // Setting up the category is not necessary, but generally advised.
+    // Since this demo records and plays, lets use AVAudioSessionCategoryPlayAndRecord.
+    // Also default to speaker as defaulting to the phone earpiece would be unusual.
+    success = [session setCategory:AVAudioSessionCategoryPlayAndRecord
+                       withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker
+                             error:&error];
+
+    if (success) {
+        NSLog(@"Calling rust_ios_main()");
+        rust_ios_main();
+    } else {
+        NSLog(@"Failed to configure audio session category");
+    }
+    
+    return YES;
+}
+
+@end

--- a/examples/ios/ios-src/Base.lproj/LaunchScreen.storyboard
+++ b/examples/ios/ios-src/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/ios-src/Base.lproj/Main.storyboard
+++ b/examples/ios/ios-src/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/ios-src/Info.plist
+++ b/examples/ios/ios-src/Info.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>coreaudio-rs feedback demo</string>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/ios/ios-src/ViewController.h
+++ b/examples/ios/ios-src/ViewController.h
@@ -1,0 +1,14 @@
+//
+//  ViewController.h
+//  coreaudio-ios-example
+//
+//  Created by Michael Hills on 2/10/20.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/examples/ios/ios-src/ViewController.m
+++ b/examples/ios/ios-src/ViewController.m
@@ -1,0 +1,22 @@
+//
+//  ViewController.m
+//  coreaudio-ios-example
+//
+//  Created by Michael Hills on 2/10/20.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+
+@end

--- a/examples/ios/ios-src/main.m
+++ b/examples/ios/ios-src/main.m
@@ -1,0 +1,18 @@
+//
+//  main.m
+//  coreaudio-ios-example
+//
+//  Created by Michael Hills on 2/10/20.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    NSString * appDelegateClassName;
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}

--- a/examples/ios/src/feedback.rs
+++ b/examples/ios/src/feedback.rs
@@ -1,0 +1,155 @@
+//! A basic input + output stream example, copying the mic input stream to the default output stream
+
+extern crate coreaudio;
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use coreaudio::audio_unit::{AudioUnit, Element, SampleFormat, Scope, StreamFormat};
+use coreaudio::audio_unit::audio_format::LinearPcmFlags;
+use coreaudio::audio_unit::render_callback::{self, data};
+use coreaudio::sys::*;
+
+const SAMPLE_RATE: f64 = 44100.0;
+
+type S = f32; const SAMPLE_FORMAT: SampleFormat = SampleFormat::F32;
+// type S = i32; const SAMPLE_FORMAT: SampleFormat = SampleFormat::I32;
+// type S = i16; const SAMPLE_FORMAT: SampleFormat = SampleFormat::I16;
+// type S = i8; const SAMPLE_FORMAT: SampleFormat = SampleFormat::I8;
+
+pub fn run_example() -> Result<(), coreaudio::Error> {
+    let mut input_audio_unit = AudioUnit::new(coreaudio::audio_unit::IOType::RemoteIO)?;
+    let mut output_audio_unit = AudioUnit::new(coreaudio::audio_unit::IOType::RemoteIO)?;
+
+    // iOS doesn't let you reconfigure an "initialized" audio unit, so uninitialize them
+    input_audio_unit.uninitialize()?;
+    output_audio_unit.uninitialize()?;
+
+    configure_for_recording(&mut input_audio_unit)?;
+
+    let format_flag = match SAMPLE_FORMAT {
+        SampleFormat::F32 => LinearPcmFlags::IS_FLOAT,
+        SampleFormat::I32 | SampleFormat::I16 | SampleFormat::I8 => LinearPcmFlags::IS_SIGNED_INTEGER,
+    };
+
+    // Using IS_NON_INTERLEAVED everywhere because data::Interleaved is commented out / not implemented
+    let in_stream_format = StreamFormat {
+        sample_rate: SAMPLE_RATE,
+        sample_format: SAMPLE_FORMAT,
+        flags: format_flag | LinearPcmFlags::IS_PACKED | LinearPcmFlags::IS_NON_INTERLEAVED,
+        // audio_unit.set_input_callback is hardcoded to 1 buffer, and when using non_interleaved
+        // we are forced to 1 channel
+        channels_per_frame: 1,
+    };
+
+    let out_stream_format = StreamFormat {
+        sample_rate: SAMPLE_RATE,
+        sample_format: SAMPLE_FORMAT,
+        flags: format_flag | LinearPcmFlags::IS_PACKED | LinearPcmFlags::IS_NON_INTERLEAVED,
+        // you can change this to 1
+        channels_per_frame: 2,
+    };
+
+    println!("input={:#?}", &in_stream_format);
+    println!("output={:#?}", &out_stream_format);
+    println!("input_asbd={:#?}", &in_stream_format.to_asbd());
+    println!("output_asbd={:#?}", &out_stream_format.to_asbd());
+
+    let id = kAudioUnitProperty_StreamFormat;
+    input_audio_unit.set_property(id, Scope::Output, Element::Input, Some(&in_stream_format.to_asbd()))?;
+    output_audio_unit.set_property(id, Scope::Input, Element::Output, Some(&out_stream_format.to_asbd()))?;
+
+    let buffer_left = Arc::new(Mutex::new(VecDeque::<S>::new()));
+    let producer_left = buffer_left.clone();
+    let consumer_left = buffer_left.clone();
+    let buffer_right = Arc::new(Mutex::new(VecDeque::<S>::new()));
+    let producer_right = buffer_right.clone();
+    let consumer_right = buffer_right.clone();
+
+    // seed roughly 1 second of data to create a delay in the feedback loop for easier testing
+    for buffer in vec![buffer_left, buffer_right] {
+        let mut buffer = buffer.lock().unwrap();
+        for _ in 0..(out_stream_format.sample_rate as i32) {
+            buffer.push_back(0 as S);
+        }
+    }
+
+    type Args = render_callback::Args<data::NonInterleaved<S>>;
+
+    println!("set_input_callback");
+    input_audio_unit.set_input_callback(move |args| {
+        let Args {
+            num_frames,
+            mut data,
+            ..
+        } = args;
+        let buffer_left = producer_left.lock().unwrap();
+        let buffer_right = producer_right.lock().unwrap();
+        let mut buffers = vec![buffer_left, buffer_right];
+        for i in 0..num_frames {
+            for (ch, channel) in data.channels_mut().enumerate() {
+                let value: S = channel[i];
+                buffers[ch].push_back(value);
+            }
+        }
+        Ok(())
+    })?;
+    input_audio_unit.initialize()?;
+    input_audio_unit.start()?;
+
+    println!("set_render_callback");
+    output_audio_unit.set_render_callback(move |args: Args| {
+        let Args {
+            num_frames,
+            mut data,
+            ..
+        } = args;
+
+        let buffer_left = consumer_left.lock().unwrap();
+        let buffer_right = consumer_right.lock().unwrap();
+        let mut buffers = vec![buffer_left, buffer_right];
+        for i in 0..num_frames {
+            // Default other channels to copy value from first channel as a fallback
+            let zero: S = 0 as S;
+            let f: S = *buffers[0].front().unwrap_or(&zero);
+            for (ch, channel) in data.channels_mut().enumerate() {
+                let sample: S = buffers[ch].pop_front().unwrap_or(f);
+                channel[i] = sample;
+            }
+        }
+        Ok(())
+    })?;
+    output_audio_unit.initialize()?;
+    output_audio_unit.start()?;
+
+    // for the purposes of this demo, leak these so that after returning the audio units will
+    // keep running
+    std::mem::forget(input_audio_unit);
+    std::mem::forget(output_audio_unit);
+
+    Ok(())
+}
+
+fn configure_for_recording(audio_unit: &mut AudioUnit) -> Result<(), coreaudio::Error> {
+    println!("Configure audio unit for recording");
+
+    // Enable mic recording
+    let enable_input = 1u32;
+    audio_unit.set_property(
+        kAudioOutputUnitProperty_EnableIO,
+        Scope::Input,
+        Element::Input,
+        Some(&enable_input),
+    )?;
+
+    // Disable output
+    let disable_output = 0u32;
+    audio_unit.set_property(
+        kAudioOutputUnitProperty_EnableIO,
+        Scope::Output,
+        Element::Output,
+        Some(&disable_output),
+    )?;
+
+    Ok(())
+}

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -1,0 +1,6 @@
+mod feedback;
+
+#[no_mangle]
+pub extern "C" fn rust_ios_main() {
+  feedback::run_example().unwrap();
+}

--- a/src/audio_unit/mod.rs
+++ b/src/audio_unit/mod.rs
@@ -323,6 +323,8 @@ impl Drop for AudioUnit {
 
             self.free_render_callback();
             self.free_input_callback();
+
+            error::Error::from_os_status(sys::AudioComponentInstanceDispose(self.instance)).ok();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/RustAudio/coreaudio-rs/issues/67

I started at https://github.com/bevyengine/bevy/issues/87 and ended up here

Some prior discussion in https://github.com/RustAudio/coreaudio-rs/pull/69

This enables building for iOS `aarch64-apple-ios` and `x86_64-apple-ios` and I managed to get audio playback on device and simulator via rodio/cpal. The actual change here affects the mic recording callback so I decided to write a feedback example app for manual testing.

- [x] https://github.com/RustAudio/coreaudio-sys/pull/33 landed and released (dependency)
- [x] Write `feedback.rs` example for macOS to test recording + playback and manually test everything works
- [x] Add an iOS Xcode project feedback example

Manually tested microphone + playback works on iOS
- [x] iPhone 6 (12.4.8)
- [x] iPad 5th gen (14.1)
- [x] iPhone 11 (14.2)
- [x] iOS simulator

There seem to be some differences between macOS and iOS CoreAudio, in that the iOS can only enable mic recording on an uninitialized AudioUnit. Similarly the iOS one requires an active AVAudioSession to do some operations like reading out the current hardware buffer size.