### PR TITLE
Publish 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-rs"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]


### PR DESCRIPTION
I'm assuming I've done the version bump right. My iOS change tweaked the input/render callbacks scope/elements so I'd rather play it safe and call it a breaking change. Would prefer not to accidentally cause breakages by people running `cargo update`.