### PR TITLE
Fix iOS CI

### DIFF
--- a/.github/workflows/coreaudio-rs.yml
+++ b/.github/workflows/coreaudio-rs.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install cargo lipo
       run: cargo install cargo-lipo
     - name: Build iphonesimulator feedback example
-      run: cd examples/ios && xcodebuild -scheme coreaudio-ios-example -configuration Debug -derivedDataPath build -sdk iphonesimulator
+      run: cd examples/ios && xcodebuild ONLY_ACTIVE_ARCH=NO ARCHS=x86_64 -scheme coreaudio-ios-example -configuration Debug -derivedDataPath build -sdk iphonesimulator
 
   # Build the docs with all features to make sure docs.rs will work.
   macos-docs:


### PR DESCRIPTION
This fixes it, but I don't understand why it is necessary. `ONLY_ACTIVE_ARCH=YES` didn't work, supposedly it should only build for x86_64 simulator with that on.