### PR TITLE
Bump crate version to 0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-rs"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]


### PR DESCRIPTION
To release https://github.com/RustAudio/coreaudio-rs/pull/91