### PR TITLE
Fix of 4 documentation warnings

### DIFF
--- a/src/audio_unit/stream_format.rs
+++ b/src/audio_unit/stream_format.rs
@@ -16,10 +16,10 @@ use sys;
 /// Seeing as `LinearPCM` data (the `AudioFormat` used by the `AudioUnit` API) implies a single
 /// frame per packet, we can infer many of the fields in an ASBD from the sample type.
 ///
-/// `bytes_per_packet` = size_of::<S>()
-/// `bytes_per_frame` = size_of::<S>()
+/// `bytes_per_packet = size_of::<S>()`
+/// `bytes_per_frame = size_of::<S>()`
 /// `frames_per_packet` = 1
-/// `bits_per_channel` = size_of::<S>() / channels_per_frame * 8
+/// `bits_per_channel = size_of::<S>()` / channels_per_frame * 8
 ///
 /// > A *packet* is a collection of one or more contiguous frames. In linear PCM audio, a packet is
 /// always a single frame.

--- a/src/audio_unit/types.rs
+++ b/src/audio_unit/types.rs
@@ -439,7 +439,7 @@ pub enum IOType {
     /// Use it for playback, recording, or low-latency simultaneous input and output where echo
     /// cancelation is not needed.
     ///
-    /// See https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/UsingSpecificAudioUnits/UsingSpecificAudioUnits.html
+    /// See <https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/UsingSpecificAudioUnits/UsingSpecificAudioUnits.html>
     /// **Available** in iOS.
     RemoteIO = 1919512419,
 }


### PR DESCRIPTION
Fix for the following warnings::
```
warning: unclosed HTML tag `S`
  --> src/audio_unit/stream_format.rs:19:35
   |
19 | /// `bytes_per_packet` = size_of::<S>()
   |                                   ^^^
   |
   = note: `#[warn(rustdoc::invalid_html_tags)]` on by default
help: try marking as source code
   |
19 | /// `bytes_per_packet` = `size_of::<S>`()
   |                          +            +

warning: unclosed HTML tag `S`
  --> src/audio_unit/stream_format.rs:20:34
   |
20 | /// `bytes_per_frame` = size_of::<S>()
   |                                  ^^^
   |
help: try marking as source code
   |
20 | /// `bytes_per_frame` = `size_of::<S>`()
   |                         +            +

warning: unclosed HTML tag `S`
  --> src/audio_unit/stream_format.rs:22:35
   |
22 | /// `bits_per_channel` = size_of::<S>() / channels_per_frame * 8
   |                                   ^^^
   |
help: try marking as source code
   |
22 | /// `bits_per_channel` = `size_of::<S>`() / channels_per_frame * 8
   |                          +            +

warning: this URL is not a hyperlink
   --> src/audio_unit/types.rs:442:13
    |
442 | ...ee https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/UsingSpecificAudioUnits/UsingSpecificAudioUnits.html
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/UsingSpecificAudioUnits/UsingSpecificAudioUnits.html>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: `coreaudio-rs` (lib doc) generated 4 warnings (run `cargo fix --lib -p coreaudio-rs` to apply 1 suggestion)

```

