### PR TITLE
Add support for scope related queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ core_midi = ["coreaudio-sys/core_midi"]
 [dependencies]
 bitflags = "1.0"
 coreaudio-sys = { version = "0.2", default-features = false }
-core-foundation-sys = "0.6.2"
+core-foundation-sys = "0.8.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/sine_advanced.rs
+++ b/examples/sine_advanced.rs
@@ -5,8 +5,8 @@ extern crate coreaudio;
 
 use coreaudio::audio_unit::audio_format::LinearPcmFlags;
 use coreaudio::audio_unit::macos_helpers::{
-    audio_unit_from_device_id, find_matching_physical_format, get_default_device_id, get_hogging_pid,
-    get_supported_physical_stream_formats, set_device_physical_stream_format,
+    audio_unit_from_device_id, find_matching_physical_format, get_default_device_id,
+    get_hogging_pid, get_supported_physical_stream_formats, set_device_physical_stream_format,
     set_device_sample_rate, toggle_hog_mode, AliveListener, RateListener,
 };
 use coreaudio::audio_unit::render_callback::{self, data};

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,8 @@ pub mod audio {
         }
     }
 
+    impl std::error::Error for Error {}
+
     impl ::std::fmt::Display for Error {
         fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
             let description = match *self {
@@ -93,6 +95,8 @@ pub mod audio_codec {
         }
     }
 
+    impl std::error::Error for Error {}
+
     impl ::std::fmt::Display for Error {
         fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
             let description = match *self {
@@ -138,6 +142,8 @@ pub mod audio_format {
             *self as OSStatus
         }
     }
+
+    impl std::error::Error for Error {}
 
     impl ::std::fmt::Display for Error {
         fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
@@ -208,6 +214,8 @@ pub mod audio_unit {
             *self as OSStatus
         }
     }
+
+    impl std::error::Error for Error {}
 
     impl ::std::fmt::Display for Error {
         fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
@@ -301,6 +309,8 @@ impl Error {
         }
     }
 }
+
+impl std::error::Error for Error {}
 
 impl ::std::fmt::Display for Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {


### PR DESCRIPTION
Added  `get_audio_device_ids_for_scope` which returns devices that are listed under a specific scope instead of just global and `get_audio_device_supports_scope` which checks if a specific devices has any channels for a scope.

This is basically a cleanup of https://github.com/RustAudio/coreaudio-rs/pull/94