### PR TITLE
Fix input and output scope and element usage. 

### DIFF
--- a/src/audio_unit/mod.rs
+++ b/src/audio_unit/mod.rs
@@ -290,27 +290,28 @@ impl AudioUnit {
         &mut self,
         stream_format: StreamFormat,
         scope: Scope,
+        element: Element,
     ) -> Result<(), Error> {
         let id = sys::kAudioUnitProperty_StreamFormat;
         let asbd = stream_format.to_asbd();
-        self.set_property(id, scope, Element::Output, Some(&asbd))
+        self.set_property(id, scope, element, Some(&asbd))
     }
 
     /// Return the current Stream Format for the AudioUnit.
-    pub fn stream_format(&self, scope: Scope) -> Result<StreamFormat, Error> {
+    pub fn stream_format(&self, scope: Scope, element: Element) -> Result<StreamFormat, Error> {
         let id = sys::kAudioUnitProperty_StreamFormat;
-        let asbd = self.get_property(id, scope, Element::Output)?;
+        let asbd = self.get_property(id, scope, element)?;
         StreamFormat::from_asbd(asbd)
     }
 
     /// Return the current output Stream Format for the AudioUnit.
     pub fn output_stream_format(&self) -> Result<StreamFormat, Error> {
-        self.stream_format(Scope::Output)
+        self.stream_format(Scope::Input, Element::Output)
     }
 
     /// Return the current input Stream Format for the AudioUnit.
     pub fn input_stream_format(&self) -> Result<StreamFormat, Error> {
-        self.stream_format(Scope::Input)
+        self.stream_format(Scope::Output, Element::Input)
     }
 }
 

--- a/src/audio_unit/render_callback.rs
+++ b/src/audio_unit/render_callback.rs
@@ -467,9 +467,7 @@ impl AudioUnit {
     {
         // First, we'll retrieve the stream format so that we can ensure that the given callback
         // format matches the audio unit's format.
-        let id = sys::kAudioUnitProperty_StreamFormat;
-        let asbd = self.get_property(id, Scope::Input, Element::Output)?;
-        let stream_format = super::StreamFormat::from_asbd(asbd)?;
+        let stream_format = self.output_stream_format()?;
 
         // If the stream format does not match, return an error indicating this.
         if !D::does_stream_format_match(&stream_format) {
@@ -540,9 +538,7 @@ impl AudioUnit {
     {
         // First, we'll retrieve the stream format so that we can ensure that the given callback
         // format matches the audio unit's format.
-        let id = sys::kAudioUnitProperty_StreamFormat;
-        let asbd = self.get_property(id, Scope::Output, Element::Input)?;
-        let stream_format = super::StreamFormat::from_asbd(asbd)?;
+        let stream_format = self.input_stream_format()?;
 
         // If the stream format does not match, return an error indicating this.
         if !D::does_stream_format_match(&stream_format) {


### PR DESCRIPTION
Getting input from a microphone needs to use the Output scope and Input Element, and sending audio to a speaker needs to use the Input Scope and Output Element. See Figure 1-3 in https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/AudioUnitHostingFundamentals/AudioUnitHostingFundamentals.html

This PR also removes a bit of redundancy in the code by reusing input and output stream functions in the callback code.