### PR TITLE
Add argument to search for device by name and scope

### DIFF
--- a/src/audio_unit/macos_helpers.rs
+++ b/src/audio_unit/macos_helpers.rs
@@ -70,17 +70,23 @@ pub fn get_default_device_id(input: bool) -> Option<AudioDeviceID> {
 }
 
 /// Find the device id for a device name.
-pub fn get_device_id_from_name(name: &str) -> Option<AudioDeviceID> {
+/// Set `input` to `true` to find a playback device, or `false` for a capture device.
+pub fn get_device_id_from_name(name: &str, input: bool) -> Option<AudioDeviceID> {
+    let scope = match input {
+        false => Scope::Output,
+        true => Scope::Input,
+    };
     if let Ok(all_ids) = get_audio_device_ids() {
         return all_ids
             .iter()
-            .find(|id| get_device_name(**id).unwrap_or_else(|_| "".to_string()) == name)
+            .find(|id| get_device_name(**id).unwrap_or_default() == name && get_audio_device_supports_scope(**id, scope).unwrap_or_default())
             .copied();
     }
     None
 }
 
 /// Create an AudioUnit instance from a device id.
+/// Set `input` to `true` to create a playback device, or `false` for a capture device.
 pub fn audio_unit_from_device_id(
     device_id: AudioDeviceID,
     input: bool,


### PR DESCRIPTION
Some devices (bluetooth headsets for example) show up as two device ids with the same name. One of these supports capture, the other playback. This PR adds an argument to the `get_device_id_from_name` helper function to get the correct device id for capture or playback.

Loosely related to https://github.com/RustAudio/coreaudio-rs/pull/104