### PR TITLE
Fix publish ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 /Cargo.lock
 .cargo/
 .DS_Store
+llvm/


### PR DESCRIPTION
This is to deal with the failed publish ci in https://github.com/RustAudio/coreaudio-rs/actions/runs/8664360312/job/23760589026#step:5:6668 as the new CI checks out LLVM in the project directory.