### PR TITLE
Add AsRef and AsMut impls for AudioUnit

### DIFF
--- a/src/audio_unit/mod.rs
+++ b/src/audio_unit/mod.rs
@@ -315,6 +315,18 @@ impl AudioUnit {
     }
 }
 
+impl AsRef<sys::AudioUnit> for AudioUnit {
+    fn as_ref(&self) -> &sys::AudioUnit {
+        &self.instance
+    }
+}
+
+impl AsMut<sys::AudioUnit> for AudioUnit {
+    fn as_mut(&mut self) -> &mut sys::AudioUnit {
+        &mut self.instance
+    }
+}
+
 unsafe impl Send for AudioUnit {}
 
 impl Drop for AudioUnit {


### PR DESCRIPTION
This patch adds implementations of `AsRef` and `AsMut` for `AudioUnit`, providing access to the underlying `sys::AudioUnit`. This is needed in some cases where functionality is missing from `coreaudio-rs` or when interfacing with other code that requires the underlying `sys::AudioUnit`.