### PR TITLE
Bump to 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-rs"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]


### PR DESCRIPTION
Release for changes in #121. I ran the changes through [`cargo semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) to be extra sure these aren't breaking changes.

Changes for this bump are for changes from [`19d3388...01ff207`](https://github.com/RustAudio/coreaudio-rs/compare/19d3388...01ff207).

@ori-sky I know it's a little silly but mind giving me a review (or just an approval)? I don't formally need it to merge but like to exercise good practice.