### PR TITLE
Use `objc2` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "coreaudio-rs"
 version = "0.12.1"
-authors = ["mitchmindtree <mitchell.nordine@gmail.com>", "yupferris <jake@fusetools.com>"]
+authors = [
+    "mitchmindtree <mitchell.nordine@gmail.com>",
+    "yupferris <jake@fusetools.com>",
+]
 description = "A friendly rust interface for Apple's CoreAudio API."
 keywords = ["core", "audio", "unit", "osx", "ios"]
 readme = "README.md"
@@ -14,19 +17,98 @@ homepage = "https://github.com/RustAudio/coreaudio-rs"
 name = "coreaudio"
 
 [features]
-default = ["audio_toolbox", "audio_unit", "core_audio", "open_al", "core_midi"]
-audio_toolbox = ["coreaudio-sys/audio_toolbox"]
-audio_unit = ["coreaudio-sys/audio_unit"]
-core_audio = ["coreaudio-sys/core_audio"]
-open_al = ["coreaudio-sys/open_al"]
-core_midi = ["coreaudio-sys/core_midi"]
+default = ["audio_toolbox", "core_audio"]
+audio_toolbox = ["dep:objc2-audio-toolbox", "dep:objc2-core-foundation"]
+core_audio = ["dep:objc2-core-audio", "dep:objc2-core-audio-types"]
+core_midi = ["dep:objc2-core-midi"]
+
+# Deprecated
+audio_unit = ["audio_toolbox"]
+
+# Unsupported
+open_al = []
 
 [dependencies]
 bitflags = "1.0"
-coreaudio-sys = { version = "0.2", default-features = false }
-core-foundation-sys = "0.8.3"
+libc = "0.2"
+objc2-core-foundation = { version = "0.3", optional = true, default-features = false, features = [
+    "std",
+    "CFBase",
+    "CFString",
+] }
+objc2-audio-toolbox = { version = "0.3", optional = true, default-features = false, features = [
+    "std",
+    "bitflags",
+    "libc",
+    "objc2-core-foundation",
+    "AUAudioUnit",
+    "AUAudioUnitImplementation",
+    "AUCocoaUIView",
+    "AUComponent",
+    "AUGraph",
+    "AUParameters",
+    "AudioCodec",
+    "AudioComponent",
+    "AudioConverter",
+    "AudioFile",
+    "AudioFileStream",
+    "AudioFormat",
+    "AudioOutputUnit",
+    "AudioQueue",
+    "AudioServices",
+    "AudioSession",
+    "AudioUnit",
+    "AudioUnitCarbonView",
+    "AudioUnitParameters",
+    "AudioUnitProperties",
+    "AudioUnitUtilities",
+    "AudioWorkInterval",
+    "CAFFile",
+    "CAShow",
+    "DefaultAudioOutput",
+    "ExtendedAudioFile",
+    "MusicDevice",
+    "MusicPlayer",
+    "objc2-core-audio",
+    "objc2-core-audio-types",
+] }
+objc2-core-audio = { version = "0.3", optional = true, default-features = false, features = [
+    "std",
+    "objc2-core-audio-types",
+    "AudioHardware",
+    "AudioHardwareDeprecated",
+    "AudioServerPlugIn",
+    "HostTime",
+] }
+objc2-core-audio-types = { version = "0.3", optional = true, default-features = false, features = [
+    "std",
+    "bitflags",
+    "AudioSessionTypes",
+    "CoreAudioBaseTypes",
+] }
+objc2-core-midi = { version = "0.3", optional = true, default-features = false, features = [
+    "std",
+    "objc2-core-foundation",
+    "MIDIBluetoothConnection",
+    "MIDICIDevice",
+    "MIDICIDeviceManager",
+    "MIDICapabilityInquiry",
+    "MIDIDriver",
+    "MIDIMessages",
+    "MIDINetworkSession",
+    "MIDIServices",
+    "MIDISetup",
+    "MIDIThruConnection",
+    "MIDIUMPCI",
+    "MIDIUMPCIProfile",
+    "MIDIUMPEndpoint",
+    "MIDIUMPEndpointManager",
+    "MIDIUMPFunctionBlock",
+    "MIDIUMPMutableEndpoint",
+    "MIDIUMPMutableFunctionBlock",
+] }
 
 [package.metadata.docs.rs]
 all-features = true
-default-target = "x86_64-apple-darwin"
-targets = ["x86_64-apple-darwin", "x86_64-apple-ios"]
+default-target = "aarch64-apple-darwin"
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-apple-ios"]

--- a/src/audio_unit/stream_format.rs
+++ b/src/audio_unit/stream_format.rs
@@ -6,7 +6,7 @@ use super::audio_format::AudioFormat;
 use super::audio_format::LinearPcmFlags;
 use super::SampleFormat;
 use crate::error::{self, Error};
-use sys;
+use crate::sys;
 
 /// A representation of the AudioStreamBasicDescription specifically for use with the AudioUnit API.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,10 +4,10 @@ pub use self::audio::Error as AudioError;
 pub use self::audio_codec::Error as AudioCodecError;
 pub use self::audio_format::Error as AudioFormatError;
 pub use self::audio_unit::Error as AudioUnitError;
-use sys::OSStatus;
+use crate::sys::OSStatus;
 
 pub mod audio {
-    use sys::OSStatus;
+    use crate::sys::OSStatus;
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
@@ -61,7 +61,7 @@ pub mod audio {
 }
 
 pub mod audio_codec {
-    use sys::OSStatus;
+    use crate::sys::OSStatus;
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
@@ -115,7 +115,7 @@ pub mod audio_codec {
 }
 
 pub mod audio_format {
-    use sys::OSStatus;
+    use crate::sys::OSStatus;
 
     // TODO: Finish implementing these values.
     #[derive(Copy, Clone, Debug)]
@@ -162,7 +162,7 @@ pub mod audio_format {
 }
 
 pub mod audio_unit {
-    use sys::OSStatus;
+    use crate::sys::OSStatus;
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,23 @@
 
 #[macro_use]
 extern crate bitflags;
-extern crate core_foundation_sys;
-pub extern crate coreaudio_sys as sys;
 
 pub use error::Error;
 
-#[cfg(feature = "audio_unit")]
+#[cfg(feature = "audio_toolbox")]
 pub mod audio_unit;
 pub mod error;
+
+pub mod sys {
+    #[cfg(feature = "audio_toolbox")]
+    pub use objc2_audio_toolbox::*;
+    #[cfg(feature = "core_audio")]
+    pub use objc2_core_audio::*;
+    #[cfg(feature = "core_audio")]
+    pub use objc2_core_audio_types::*;
+    #[cfg(feature = "core_midi")]
+    pub use objc2_core_midi::*;
+
+    // MacTypes.h
+    pub type OSStatus = i32;
+}


### PR DESCRIPTION
Use the [`objc2-*`](https://docs.rs/objc2/0.6.0/objc2/topics/about_generated/index.html) crates instead of `coreaudio-sys` (you knew it was coming @simlay 😉):
- `objc2-audio-toolbox`.
- `objc2-core-audio`.
- `objc2-core-audio-types`.
- `objc2-core-midi`.

**Resolves every single [`coreaudio-sys` issue](https://github.com/RustAudio/coreaudio-sys/issues)[^1] and [PR](https://github.com/RustAudio/coreaudio-sys/pulls)** by no longer invoking `bindgen`, and instead generating the headers ahead of time. We should probably deprecate `coreaudio-sys` and archive the repo once this lands.

The bindings generated by `objc2`'s tool `header-translator` are also a bit more type-safe as they include for example nullability information, and is able to merge some enum constants into constants on the enum type.

Tested with `sine` example on:
- macOS 10.12.6
- macOS 14.7.1

Note: We've experienced problems with linking AudioUnix in the past, see https://github.com/RustAudio/coreaudio-sys/pull/51, but that should be irrelevant since we now just always link AudioToolbox. This is fine, since AudioUnit has been an empty re-export of parts of AudioToolbox since macOS 10.10 (and [`rustc`'s minimum supported macOS version](https://doc.rust-lang.org/1.84.0/rustc/platform-support/apple-darwin.html#os-version) is 10.12) [^2].

Note: I am unsure of your MSRV, but this will at least bump it to 1.71 (required for `extern "C-unwind"`).

[^1]: Okay, maybe RustAudio/coreaudio-sys#40 isn't quite resolved, since `objc2-core-audio` [also failed building docs](https://docs.rs/crate/objc2-audio-toolbox/0.3.0/builds/1665459), but that's a minor issue.

[^2]: If you really want to, we _could_ add `#[link(name = "AudioUnit", kind = "framework")] extern "C" {}` to still support older macOS versions.