### PR TITLE
Include OSStatus when formatting the Unknown error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -328,7 +328,7 @@ impl ::std::fmt::Display for Error {
             Error::AudioCodec(ref err) => write!(f, "{}", err),
             Error::AudioFormat(ref err) => write!(f, "{}", err),
             Error::AudioUnit(ref err) => write!(f, "{}", err),
-            Error::Unknown(_) => write!(f, "An unknown error unknown to the coreaudio-rs API occurred"),
+            Error::Unknown(os_status) => write!(f, "An error unknown to the coreaudio-rs API occurred, OSStatus: {}", os_status),
         }
     }
 }


### PR DESCRIPTION
The current implementation does not include the OSStatus when formatting an unknown error. The number is there but isn't being used. This PR simply includes it in the message. Without this it is very difficult to figure out what goes wrong whenever an error occurs and it's not one of the expected ones.