### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/sine_advanced.rs
+++ b/examples/sine_advanced.rs
@@ -7,8 +7,11 @@ use coreaudio::audio_unit::audio_format::LinearPcmFlags;
 use coreaudio::audio_unit::macos_helpers::{
     audio_unit_from_device_id, find_matching_physical_format, get_default_device_id,
     get_hogging_pid, get_supported_physical_stream_formats, set_device_physical_stream_format,
-    set_device_sample_rate, toggle_hog_mode, AliveListener, RateListener,
+    toggle_hog_mode, AliveListener, RateListener,
 };
+// This import is not needed since the use of set_device_sample_rate
+// is commented out and left as an example.
+// use coreaudio::audio_unit::macos_helpers::set_device_sample_rate;
 use coreaudio::audio_unit::render_callback::{self, data};
 use coreaudio::audio_unit::{Element, SampleFormat, Scope, StreamFormat};
 use objc2_audio_toolbox::kAudioUnitProperty_StreamFormat;

--- a/src/audio_unit/macos_helpers.rs
+++ b/src/audio_unit/macos_helpers.rs
@@ -63,7 +63,7 @@ pub fn get_default_device_id(input: bool) -> Option<AudioDeviceID> {
             NonNull::from(&mut audio_device_id).cast(),
         )
     };
-    if status != kAudioHardwareNoError as i32 {
+    if status != kAudioHardwareNoError {
         return None;
     }
 
@@ -248,7 +248,7 @@ pub fn get_audio_device_supports_scope(devid: AudioDeviceID, scope: Scope) -> Re
             NonNull::from(&data_size),
             NonNull::new(buffers).unwrap().cast(),
         );
-        if status != kAudioHardwareNoError as i32 {
+        if status != kAudioHardwareNoError {
             return Err(Error::Unknown(status));
         }
 
@@ -333,7 +333,7 @@ pub fn set_device_sample_rate(device_id: AudioDeviceID, new_rate: f64) -> Result
             Error::from_os_status(status)?;
             let n_ranges = data_size as usize / mem::size_of::<AudioValueRange>();
             let mut ranges: Vec<AudioValueRange> = vec![];
-            ranges.reserve_exact(n_ranges as usize);
+            ranges.reserve_exact(n_ranges);
             ranges.set_len(n_ranges);
             let status = AudioObjectGetPropertyData(
                 device_id,
@@ -559,7 +559,7 @@ pub fn get_supported_physical_stream_formats(
         Error::from_os_status(status)?;
         let n_formats = data_size as usize / mem::size_of::<AudioStreamRangedDescription>();
         let mut formats: Vec<AudioStreamRangedDescription> = vec![];
-        formats.reserve_exact(n_formats as usize);
+        formats.reserve_exact(n_formats);
         formats.set_len(n_formats);
 
         let status = AudioObjectGetPropertyData(

--- a/src/audio_unit/render_callback.rs
+++ b/src/audio_unit/render_callback.rs
@@ -504,7 +504,7 @@ impl AudioUnit {
                     data,
                     time_stamp: in_time_stamp.read(),
                     flags,
-                    bus_number: in_bus_number as u32,
+                    bus_number: in_bus_number,
                     num_frames: in_number_frames as usize,
                 }
             };
@@ -678,7 +678,7 @@ impl AudioUnit {
                     data,
                     time_stamp: in_time_stamp.read(),
                     flags,
-                    bus_number: in_bus_number as u32,
+                    bus_number: in_bus_number,
                     num_frames: in_number_frames as usize,
                 }
             };
@@ -744,7 +744,7 @@ impl AudioUnit {
                 // Take ownership over the AudioBufferList in order to safely free it.
                 let buffer_list: Box<AudioBufferList> = Box::from_raw(buffer_list);
                 // Free the allocated data from the individual audio buffers.
-                let ptr = buffer_list.mBuffers.as_ptr() as *const AudioBuffer;
+                let ptr = buffer_list.mBuffers.as_ptr();
                 let len = buffer_list.mNumberBuffers as usize;
                 let buffers: &[AudioBuffer] = slice::from_raw_parts(ptr, len);
                 for &buffer in buffers {

--- a/src/audio_unit/stream_format.rs
+++ b/src/audio_unit/stream_format.rs
@@ -23,7 +23,7 @@ use crate::error::{self, Error};
 /// `bits_per_channel = size_of::<S>()` / channels_per_frame * 8
 ///
 /// > A *packet* is a collection of one or more contiguous frames. In linear PCM audio, a packet is
-/// always a single frame.
+/// > always a single frame.
 ///
 /// [from *Core Audio Overview*](https://developer.apple.com/library/ios/documentation/MusicAudio/Conceptual/CoreAudioOverview/WhatisCoreAudio/WhatisCoreAudio.html)
 ///
@@ -31,10 +31,10 @@ use crate::error::{self, Error};
 /// >
 /// > - iOS input and output: Linear PCM with 16-bit integer samples.
 /// > - iOS audio units and other audio processing: Noninterleaved linear PCM with 8.24-bit
-/// fixed-point samples
+/// >   fixed-point samples
 /// > - Mac input and output: Linear PCM with 32-bit floating point samples.
 /// > - Mac audio units and other audio processing: Noninterleaved linear PCM with 32-bit floating
-/// point samples.
+/// >   point samples.
 #[derive(Copy, Clone, Debug)]
 pub struct StreamFormat {
     /// The number of frames of audio data per second used to represent a signal.
@@ -61,7 +61,7 @@ impl StreamFormat {
     /// specified in the documentation:
     ///
     /// > Specify kAudioFormatLinearPCM for the mFormatID field. Audio units use uncompressed audio
-    /// data, so this is the correct format identifier to use whenever you work with audio units.
+    /// > data, so this is the correct format identifier to use whenever you work with audio units.
     ///
     /// [*Audio Unit Hosting Guide for iOS*](https://developer.apple.com/library/ios/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/AudioUnitHostingFundamentals/AudioUnitHostingFundamentals.html)
     ///
@@ -118,7 +118,7 @@ impl StreamFormat {
         let (format, maybe_flag) =
             AudioFormat::LinearPCM(flags | LinearPcmFlags::IS_PACKED).as_format_and_flag();
 
-        let flag = maybe_flag.unwrap_or(::std::u32::MAX - 2147483647);
+        let flag = maybe_flag.unwrap_or(u32::MAX - 2147483647);
 
         let non_interleaved = flags.contains(LinearPcmFlags::IS_NON_INTERLEAVED);
         let bytes_per_frame = if non_interleaved {

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,7 @@ pub mod audio {
                 Error::MemFull => "Memory full",
                 Error::Unknown => "An unknown error occurred",
             };
-            write!(f, "{}", description)
+            write!(f, "{description}")
         }
     }
 }
@@ -109,7 +109,7 @@ pub mod audio_codec {
                 Error::NotEnoughBufferSpace => "Not enough buffer space",
                 Error::Unknown => "Unknown error occurred",
             };
-            write!(f, "{}", description)
+            write!(f, "{description}")
         }
     }
 }
@@ -156,7 +156,7 @@ pub mod audio_format {
                 Error::UnknownFormat => "The specified data format is not a known format",
                 Error::Unknown => "Unknown error occurred",
             };
-            write!(f, "{}", description)
+            write!(f, "{description}")
         }
     }
 }
@@ -239,7 +239,7 @@ pub mod audio_unit {
                 Error::Unauthorized => "Unauthorized",
                 Error::Unknown => "Unknown error occurred",
             };
-            write!(f, "{}", description)
+            write!(f, "{description}")
         }
     }
 }
@@ -324,11 +324,11 @@ impl ::std::fmt::Display for Error {
             Error::NonInterleavedInputOnlySupportsMono => write!(f, "In non-interleaved mode input only supports one channel"),
             Error::UnsupportedSampleRate => write!(f, "The requested sample rate is not available"),
             Error::UnsupportedStreamFormat => write!(f, "The requested stream format is not available"),
-            Error::Audio(ref err) => write!(f, "{}", err),
-            Error::AudioCodec(ref err) => write!(f, "{}", err),
-            Error::AudioFormat(ref err) => write!(f, "{}", err),
-            Error::AudioUnit(ref err) => write!(f, "{}", err),
-            Error::Unknown(os_status) => write!(f, "An error unknown to the coreaudio-rs API occurred, OSStatus: {}", os_status),
+            Error::Audio(ref err) => write!(f, "{err}"),
+            Error::AudioCodec(ref err) => write!(f, "{err}"),
+            Error::AudioFormat(ref err) => write!(f, "{err}"),
+            Error::AudioUnit(ref err) => write!(f, "{err}"),
+            Error::Unknown(os_status) => write!(f, "An error unknown to the coreaudio-rs API occurred, OSStatus: {os_status}"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -328,7 +328,7 @@ impl ::std::fmt::Display for Error {
             Error::AudioCodec(ref err) => write!(f, "{}", err),
             Error::AudioFormat(ref err) => write!(f, "{}", err),
             Error::AudioUnit(ref err) => write!(f, "{}", err),
-            Error::Unknown(_) => write!(f, "An unknown error unknown to the coreaudio-rs API occurred"),
+            Error::Unknown(os_status) => write!(f, "An error unknown to the coreaudio-rs API occurred, OSStatus: {}", os_status),
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issues clippy finds. The most important ones are the `set_property` and `get_property` functions in the audio_unit module. They trigger the `not_unsafe_ptr_arg_deref` lint because they accept a pointer to an AudioUnit instance, but they cannot check that the pointer is valid, and therefore the caller must be responsible for this. They should be marked as unsafe to reflect this. Instead using the associated methods on the AudioUnit structure is safe and should be the preferred way.

The clippy docs strongly recommend against disabling the `not_unsafe_ptr_arg_deref` rule, so I marked the functions as unsafe. This is a small breaking change, but this still seems like a better alternative than disabling the rule (and we could also discuss if these functions should be `pub` at all, but now they are, so removing them from the public api could cause trouble for some users).