### PR TITLE
Import all constants from objc2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,12 @@ objc2-audio-toolbox = { version = "0.3", optional = true, default-features = fal
     "objc2-core-audio",
     "objc2-core-audio-types",
     "AUComponent",
+    "AudioCodec",
     "AudioComponent",
+    "AudioFormat",
     "AudioOutputUnit",
     "AudioUnitProperties",
+    "AudioServices",
     "AudioSession",
 ] }
 objc2-core-audio = { version = "0.3", optional = true, default-features = false, features = [

--- a/src/audio_unit/audio_format.rs
+++ b/src/audio_unit/audio_format.rs
@@ -3,6 +3,25 @@
 //! See the Core Audio Data Types Reference
 //! [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Data_Format_Identifiers) for more info.
 
+use objc2_core_audio_types::{
+    kAppleLosslessFormatFlag_16BitSourceData, kAppleLosslessFormatFlag_20BitSourceData,
+    kAppleLosslessFormatFlag_24BitSourceData, kAppleLosslessFormatFlag_32BitSourceData,
+    kAudioFormat60958AC3, kAudioFormatAC3, kAudioFormatAES3, kAudioFormatALaw, kAudioFormatAMR,
+    kAudioFormatAMR_WB, kAudioFormatAppleIMA4, kAudioFormatAppleLossless, kAudioFormatAudible,
+    kAudioFormatDVIIntelIMA, kAudioFormatFlagIsAlignedHigh, kAudioFormatFlagIsBigEndian,
+    kAudioFormatFlagIsFloat, kAudioFormatFlagIsNonInterleaved, kAudioFormatFlagIsNonMixable,
+    kAudioFormatFlagIsPacked, kAudioFormatFlagIsSignedInteger, kAudioFormatLinearPCM,
+    kAudioFormatMACE3, kAudioFormatMACE6, kAudioFormatMIDIStream, kAudioFormatMPEG4AAC,
+    kAudioFormatMPEG4AAC_ELD, kAudioFormatMPEG4AAC_ELD_SBR, kAudioFormatMPEG4AAC_ELD_V2,
+    kAudioFormatMPEG4AAC_HE, kAudioFormatMPEG4AAC_HE_V2, kAudioFormatMPEG4AAC_LD,
+    kAudioFormatMPEG4AAC_Spatial, kAudioFormatMPEG4CELP, kAudioFormatMPEG4HVXC,
+    kAudioFormatMPEG4TwinVQ, kAudioFormatMPEGLayer1, kAudioFormatMPEGLayer2,
+    kAudioFormatMPEGLayer3, kAudioFormatMicrosoftGSM, kAudioFormatParameterValueStream,
+    kAudioFormatQDesign, kAudioFormatQDesign2, kAudioFormatQUALCOMM, kAudioFormatTimeCode,
+    kAudioFormatULaw, kAudioFormatiLBC, kLinearPCMFormatFlagsSampleFractionMask,
+    kLinearPCMFormatFlagsSampleFractionShift, AudioTimeStampFlags as Objc2AudioTimeStampFlags,
+    MPEG4ObjectID as Objc2MPEG4ObjectID,
+};
 use std::os::raw::c_uint;
 
 /// A type-safe representation of both the `AudioFormatId` and their associated flags.
@@ -12,80 +31,80 @@ pub enum AudioFormat {
     /// Linear PCM; a non-compressed audio data format with one frame per packet.
     ///
     /// **Available** in OS X v10.0 and later.
-    LinearPCM(LinearPcmFlags), // = 1819304813,
+    LinearPCM(LinearPcmFlags),
     /// An AC-3 codec.
     ///
     /// **Available** in OS X v10.2 and later.
-    AC3, // = 1633889587,
+    AC3,
     /// AC-3 codec that provides data packaged for transport over an IEC 60958 compliant digital
     /// audio interface.
     ///
     /// **Available** in OS X v10.2 and later.
-    F60958AC3(StandardFlags), // = 1667326771,
+    F60958AC3(StandardFlags),
     /// Apple's implementation of the IMA 4:1 ADPCM codec.
     ///
     /// **Available** in OS X v10.2 and later.
-    AppleIMA4, // = 1768775988,
+    AppleIMA4,
     /// MPEG-4 AAC codec.
     ///
     /// **Available** in OS X v10.2 and later.
-    MPEG4AAC(Mpeg4ObjectId), // = 1633772320,
+    MPEG4AAC(Mpeg4ObjectId),
     /// MPEG-4 CELP codec.
     ///
     /// **Available** in OS X v10.2 and later.
-    MPEG4CELP(Mpeg4ObjectId), // = 1667591280,
+    MPEG4CELP(Mpeg4ObjectId),
     /// MPEG-4 HVXC codec.
     ///
     /// **Available** in OS X v10.2 and later.
-    MPEG4HVXC(Mpeg4ObjectId), // = 1752594531,
+    MPEG4HVXC(Mpeg4ObjectId),
     /// MPEG-4 TwinVQ codec.
     ///
     /// **Available** in OS X v10.2 and later.
-    MPEG4TwinVQ(Mpeg4ObjectId), // = 1953986161,
+    MPEG4TwinVQ(Mpeg4ObjectId),
     /// MACE 3:1.
     ///
     /// **Available** in OS X v10.3 and later.
-    MACE3, // = 1296122675,
+    MACE3,
     /// MACE 6:1.
     ///
     /// **Available** in OS X v10.3 and later.
-    MACE6, // = 1296122678,
+    MACE6,
     /// μLaw 2:1.
     ///
     /// **Available** in OS X v10.3 and later.
-    ULaw, // = 1970037111,
+    ULaw,
     /// aLaw 2:1.
     ///
     /// **Available** in OS X v10.3 and later.
-    ALaw, // = 1634492791,
+    ALaw,
     /// QDesign Music.
     ///
     /// **Available** in OS X v10.3 and later.
-    QDesign, // = 1363430723,
+    QDesign,
     /// QDesign2 Music.
     ///
     /// **Available** in OS X v10.3 and later.
-    QDesign2, // = 1363430706,
+    QDesign2,
     /// QUALCOMM PureVoice.
     ///
     /// **Available** in OS X v10.3 and later.
-    QUALCOMM, // = 1365470320,
+    QUALCOMM,
     /// MPEG-1/2, Layer 1 audio.
     ///
     /// **Available** in OS X v10.3 and later.
-    MPEGLayer1, // = 778924081,
+    MPEGLayer1,
     /// MPEG-1/2, Layer 2 audio.
     ///
     /// **Available** in OS X v10.3 and later.
-    MPEGLayer2, // = 778924082,
+    MPEGLayer2,
     /// MPEG-1/2, Layer 3 audio.
     ///
     /// **Available** in OS X v10.3 and later.
-    MPEGLayer3, // = 778924083,
+    MPEGLayer3,
     /// A stream of IOAudioTimeStamp structures.
     ///
     /// **Available** in OS X v10.2 and later.
-    TimeCode(AudioTimeStampFlags), // = 1953066341,
+    TimeCode(AudioTimeStampFlags),
     /// A stream of MIDIPacketList structures where the time stamps in the MIDIPacket structures
     /// are sample offsets in the stream. The `sample_rate` field in the **StreamFormat** structure
     /// is used to describe how time is passed in this kind of stream.
@@ -100,7 +119,7 @@ pub enum AudioFormat {
     ///
     /// TODO: Review whether or not this audio format should indicate some fundamental change
     /// within the **StreamFormat**.
-    MIDIStream, // = 1835623529,
+    MIDIStream,
     /// A "side-chain" of f32 data that can be fed or generated by an audio unit and that is used
     /// to send a high density of parameter value control information.
     ///
@@ -111,121 +130,123 @@ pub enum AudioFormat {
     /// The `sample_rate` field in the **StreamFormat** type describes this relationship.
     ///
     /// **Available** in OS X v10.2 and later.
-    ParameterValueStream, // = 1634760307,
+    ParameterValueStream,
     /// Apple Lossless format.
     ///
     /// **Available** in OS X v10.3 and later.
-    AppleLossless(AppleLosslessFlags), // = 1634492771,
+    AppleLossless(AppleLosslessFlags),
     /// MPEG-4 High Efficiency AAC audio object.
     ///
     /// **Available** in OS X v10.5 and later.
-    MPEG4AAC_HE, // = 1633772392,
+    MPEG4AAC_HE,
     /// MPEG-4 AAC Low Delay audio object.
     ///
     /// **Available** in OS X v10.5 and later.
-    MPEG4AAC_LD, // = 1633772396,
+    MPEG4AAC_LD,
     /// MPEG-4 AAC Enhanced Low Delay audio object.
     ///
     /// **Available** in OS X v10.7 and later.
-    MPEG4AAC_ELD, // = 1633772389,
+    MPEG4AAC_ELD,
     /// MPEG-4 AAC Enhanced Low Delay audio object with SBR (spectral band replication) extension
     /// layer.
     ///
     /// **Available** in OS X v10.7 and later.
-    MPEG4AAC_ELD_SBR, // = 1633772390,
-    MPEG4AAC_ELD_V2, // = 1633772391,
+    MPEG4AAC_ELD_SBR,
+    MPEG4AAC_ELD_V2,
     /// MPEG-4 High Efficiency AAC Version 2 audio object.
     ///
     /// **Available** in OS X v10.5 and later.
-    MPEG4AAC_HE_V2, // = 1633772400,
+    MPEG4AAC_HE_V2,
     /// MPEG-4 Apatial Audio audio object.
     ///
     /// **Available** in OS X v10.5 and later.
-    MPEG4AAC_Spatial, // = 1633772403,
+    MPEG4AAC_Spatial,
     /// The AMR (adaptive Multi-Rate) narrow band speech codec.
     ///
     /// **Available** in OS X v10.5 and later.
-    AMR, // = 1935764850,
-    AMR_WB,          // = 1935767394,
+    AMR,
+    AMR_WB,
     /// The codec used for Audible, Inc. audio books.
     ///
     /// **Available** in OS X v10.6 and later.
-    Audible, // = 1096107074,
+    Audible,
     /// The iLBC (internet Low Bitrate Codec) narrow band cpeech codec.
     ///
     /// **Available** in OS X v10.6 and later.
-    iLBC, // = 1768710755,
+    iLBC,
     /// DVI/Intel IMA ADPCM - ACM code 17.
     ///
     /// **Available** in OS X v10.6 and later.
-    DVIIntelIMA, // = 1836253201,
+    DVIIntelIMA,
     /// Microsoft GSM 6.10 - ACM code 49.
     ///
     /// **Available** in OS X v10.6 and later.
-    MicrosoftGSM, // = 1836253233,
+    MicrosoftGSM,
     /// The format defined by the AES3-2003 standard.
     ///
     /// Adopted into MXF and MPEG-2 containers and SDTI transport streams with SMPTE specs
     /// 203M-2002 and 331M-2000.
-    AES3, // = 1634038579,
+    AES3,
 }
 
 impl AudioFormat {
     /// Convert from the FFI C format and flags to a typesafe Rust enum representation.
     pub fn from_format_and_flag(format: c_uint, flag: Option<u32>) -> Option<AudioFormat> {
         match (format, flag) {
-            (1819304813, Some(i)) => Some(AudioFormat::LinearPCM(
+            (_, Some(i)) if format == kAudioFormatLinearPCM => Some(AudioFormat::LinearPCM(
                 LinearPcmFlags::from_bits_truncate(i),
             )),
-            (1633889587, _) => Some(AudioFormat::AC3),
-            (1667326771, Some(i)) => {
+            (_, _) if format == kAudioFormatAC3 => Some(AudioFormat::AC3),
+            (_, Some(i)) if format == kAudioFormat60958AC3 => {
                 Some(AudioFormat::F60958AC3(StandardFlags::from_bits_truncate(i)))
             }
-            (1768775988, _) => Some(AudioFormat::AppleIMA4),
-            (1633772320, Some(i)) => Some(AudioFormat::MPEG4AAC(
+            (_, _) if format == kAudioFormatAppleIMA4 => Some(AudioFormat::AppleIMA4),
+            (_, Some(i)) if format == kAudioFormatMPEG4AAC => Some(AudioFormat::MPEG4AAC(
                 Mpeg4ObjectId::from_u32(i).expect("Unknown Mpeg4ObjectId"),
             )),
-            (1667591280, Some(i)) => Some(AudioFormat::MPEG4CELP(
+            (_, Some(i)) if format == kAudioFormatMPEG4CELP => Some(AudioFormat::MPEG4CELP(
                 Mpeg4ObjectId::from_u32(i).expect("Unknown Mpeg4ObjectId"),
             )),
-            (1752594531, Some(i)) => Some(AudioFormat::MPEG4HVXC(
+            (_, Some(i)) if format == kAudioFormatMPEG4HVXC => Some(AudioFormat::MPEG4HVXC(
                 Mpeg4ObjectId::from_u32(i).expect("Unknown Mpeg4ObjectId"),
             )),
-            (1953986161, Some(i)) => Some(AudioFormat::MPEG4TwinVQ(
+            (_, Some(i)) if format == kAudioFormatMPEG4TwinVQ => Some(AudioFormat::MPEG4TwinVQ(
                 Mpeg4ObjectId::from_u32(i).expect("Unknown Mpeg4ObjectId"),
             )),
-            (1296122675, _) => Some(AudioFormat::MACE3),
-            (1296122678, _) => Some(AudioFormat::MACE6),
-            (1970037111, _) => Some(AudioFormat::ULaw),
-            (1634492791, _) => Some(AudioFormat::ALaw),
-            (1363430723, _) => Some(AudioFormat::QDesign),
-            (1363430706, _) => Some(AudioFormat::QDesign2),
-            (1365470320, _) => Some(AudioFormat::QUALCOMM),
-            (778924081, _) => Some(AudioFormat::MPEGLayer1),
-            (778924082, _) => Some(AudioFormat::MPEGLayer2),
-            (778924083, _) => Some(AudioFormat::MPEGLayer3),
-            (1953066341, Some(i)) => Some(AudioFormat::TimeCode(
+            (_, _) if format == kAudioFormatMACE3 => Some(AudioFormat::MACE3),
+            (_, _) if format == kAudioFormatMACE6 => Some(AudioFormat::MACE6),
+            (_, _) if format == kAudioFormatULaw => Some(AudioFormat::ULaw),
+            (_, _) if format == kAudioFormatALaw => Some(AudioFormat::ALaw),
+            (_, _) if format == kAudioFormatQDesign => Some(AudioFormat::QDesign),
+            (_, _) if format == kAudioFormatQDesign2 => Some(AudioFormat::QDesign2),
+            (_, _) if format == kAudioFormatQUALCOMM => Some(AudioFormat::QUALCOMM),
+            (_, _) if format == kAudioFormatMPEGLayer1 => Some(AudioFormat::MPEGLayer1),
+            (_, _) if format == kAudioFormatMPEGLayer2 => Some(AudioFormat::MPEGLayer2),
+            (_, _) if format == kAudioFormatMPEGLayer3 => Some(AudioFormat::MPEGLayer3),
+            (_, Some(i)) if format == kAudioFormatTimeCode => Some(AudioFormat::TimeCode(
                 AudioTimeStampFlags::from_bits_truncate(i),
             )),
-            (1835623529, _) => Some(AudioFormat::MIDIStream),
-            (1634760307, _) => Some(AudioFormat::ParameterValueStream),
-            (1634492771, Some(i)) => Some(AudioFormat::AppleLossless(
-                AppleLosslessFlags::from_bits_truncate(i),
-            )),
-            (1633772392, _) => Some(AudioFormat::MPEG4AAC_HE),
-            (1633772396, _) => Some(AudioFormat::MPEG4AAC_LD),
-            (1633772389, _) => Some(AudioFormat::MPEG4AAC_ELD),
-            (1633772390, _) => Some(AudioFormat::MPEG4AAC_ELD_SBR),
-            (1633772391, _) => Some(AudioFormat::MPEG4AAC_ELD_V2),
-            (1633772400, _) => Some(AudioFormat::MPEG4AAC_HE_V2),
-            (1633772403, _) => Some(AudioFormat::MPEG4AAC_Spatial),
-            (1935764850, _) => Some(AudioFormat::AMR),
-            (1935767394, _) => Some(AudioFormat::AMR_WB),
-            (1096107074, _) => Some(AudioFormat::Audible),
-            (1768710755, _) => Some(AudioFormat::iLBC),
-            (1836253201, _) => Some(AudioFormat::DVIIntelIMA),
-            (1836253233, _) => Some(AudioFormat::MicrosoftGSM),
-            (1634038579, _) => Some(AudioFormat::AES3),
+            (_, _) if format == kAudioFormatMIDIStream => Some(AudioFormat::MIDIStream),
+            (_, _) if format == kAudioFormatParameterValueStream => {
+                Some(AudioFormat::ParameterValueStream)
+            }
+            (_, Some(i)) if format == kAudioFormatAppleLossless => Some(
+                AudioFormat::AppleLossless(AppleLosslessFlags::from_bits_truncate(i)),
+            ),
+            (_, _) if format == kAudioFormatMPEG4AAC_HE => Some(AudioFormat::MPEG4AAC_HE),
+            (_, _) if format == kAudioFormatMPEG4AAC_LD => Some(AudioFormat::MPEG4AAC_LD),
+            (_, _) if format == kAudioFormatMPEG4AAC_ELD => Some(AudioFormat::MPEG4AAC_ELD),
+            (_, _) if format == kAudioFormatMPEG4AAC_ELD_SBR => Some(AudioFormat::MPEG4AAC_ELD_SBR),
+            (_, _) if format == kAudioFormatMPEG4AAC_ELD_V2 => Some(AudioFormat::MPEG4AAC_ELD_V2),
+            (_, _) if format == kAudioFormatMPEG4AAC_HE_V2 => Some(AudioFormat::MPEG4AAC_HE_V2),
+            (_, _) if format == kAudioFormatMPEG4AAC_Spatial => Some(AudioFormat::MPEG4AAC_Spatial),
+            (_, _) if format == kAudioFormatAMR => Some(AudioFormat::AMR),
+            (_, _) if format == kAudioFormatAMR_WB => Some(AudioFormat::AMR_WB),
+            (_, _) if format == kAudioFormatAudible => Some(AudioFormat::Audible),
+            (_, _) if format == kAudioFormatiLBC => Some(AudioFormat::iLBC),
+            (_, _) if format == kAudioFormatDVIIntelIMA => Some(AudioFormat::DVIIntelIMA),
+            (_, _) if format == kAudioFormatMicrosoftGSM => Some(AudioFormat::MicrosoftGSM),
+            (_, _) if format == kAudioFormatAES3 => Some(AudioFormat::AES3),
             _ => None,
         }
     }
@@ -233,42 +254,42 @@ impl AudioFormat {
     /// Convert from the Rust enum to the C format and flag.
     pub fn as_format_and_flag(&self) -> (c_uint, Option<u32>) {
         match *self {
-            AudioFormat::LinearPCM(flag) => (1819304813, Some(flag.bits())),
-            AudioFormat::AC3 => (1633889587, None),
-            AudioFormat::F60958AC3(flag) => (1667326771, Some(flag.bits())),
-            AudioFormat::AppleIMA4 => (1768775988, None),
-            AudioFormat::MPEG4AAC(flag) => (1633772320, Some(flag as u32)),
-            AudioFormat::MPEG4CELP(flag) => (1667591280, Some(flag as u32)),
-            AudioFormat::MPEG4HVXC(flag) => (1752594531, Some(flag as u32)),
-            AudioFormat::MPEG4TwinVQ(flag) => (1953986161, Some(flag as u32)),
-            AudioFormat::MACE3 => (1296122675, None),
-            AudioFormat::MACE6 => (1296122678, None),
-            AudioFormat::ULaw => (1970037111, None),
-            AudioFormat::ALaw => (1634492791, None),
-            AudioFormat::QDesign => (1363430723, None),
-            AudioFormat::QDesign2 => (1363430706, None),
-            AudioFormat::QUALCOMM => (1365470320, None),
-            AudioFormat::MPEGLayer1 => (778924081, None),
-            AudioFormat::MPEGLayer2 => (778924082, None),
-            AudioFormat::MPEGLayer3 => (778924083, None),
-            AudioFormat::TimeCode(flag) => (1953066341, Some(flag.bits())),
-            AudioFormat::MIDIStream => (1835623529, None),
-            AudioFormat::ParameterValueStream => (1634760307, None),
-            AudioFormat::AppleLossless(flag) => (1634492771, Some(flag.bits())),
-            AudioFormat::MPEG4AAC_HE => (1633772392, None),
-            AudioFormat::MPEG4AAC_LD => (1633772396, None),
-            AudioFormat::MPEG4AAC_ELD => (1633772389, None),
-            AudioFormat::MPEG4AAC_ELD_SBR => (1633772390, None),
-            AudioFormat::MPEG4AAC_ELD_V2 => (1633772391, None),
-            AudioFormat::MPEG4AAC_HE_V2 => (1633772400, None),
-            AudioFormat::MPEG4AAC_Spatial => (1633772403, None),
-            AudioFormat::AMR => (1935764850, None),
-            AudioFormat::AMR_WB => (1935767394, None),
-            AudioFormat::Audible => (1096107074, None),
-            AudioFormat::iLBC => (1768710755, None),
-            AudioFormat::DVIIntelIMA => (1836253201, None),
-            AudioFormat::MicrosoftGSM => (1836253233, None),
-            AudioFormat::AES3 => (1634038579, None),
+            AudioFormat::LinearPCM(flag) => (kAudioFormatLinearPCM, Some(flag.bits())),
+            AudioFormat::AC3 => (kAudioFormatAC3, None),
+            AudioFormat::F60958AC3(flag) => (kAudioFormat60958AC3, Some(flag.bits())),
+            AudioFormat::AppleIMA4 => (kAudioFormatAppleIMA4, None),
+            AudioFormat::MPEG4AAC(flag) => (kAudioFormatMPEG4AAC, Some(flag as u32)),
+            AudioFormat::MPEG4CELP(flag) => (kAudioFormatMPEG4CELP, Some(flag as u32)),
+            AudioFormat::MPEG4HVXC(flag) => (kAudioFormatMPEG4HVXC, Some(flag as u32)),
+            AudioFormat::MPEG4TwinVQ(flag) => (kAudioFormatMPEG4TwinVQ, Some(flag as u32)),
+            AudioFormat::MACE3 => (kAudioFormatMACE3, None),
+            AudioFormat::MACE6 => (kAudioFormatMACE6, None),
+            AudioFormat::ULaw => (kAudioFormatULaw, None),
+            AudioFormat::ALaw => (kAudioFormatALaw, None),
+            AudioFormat::QDesign => (kAudioFormatQDesign, None),
+            AudioFormat::QDesign2 => (kAudioFormatQDesign2, None),
+            AudioFormat::QUALCOMM => (kAudioFormatQUALCOMM, None),
+            AudioFormat::MPEGLayer1 => (kAudioFormatMPEGLayer1, None),
+            AudioFormat::MPEGLayer2 => (kAudioFormatMPEGLayer2, None),
+            AudioFormat::MPEGLayer3 => (kAudioFormatMPEGLayer3, None),
+            AudioFormat::TimeCode(flag) => (kAudioFormatTimeCode, Some(flag.bits())),
+            AudioFormat::MIDIStream => (kAudioFormatMIDIStream, None),
+            AudioFormat::ParameterValueStream => (kAudioFormatParameterValueStream, None),
+            AudioFormat::AppleLossless(flag) => (kAudioFormatAppleLossless, Some(flag.bits())),
+            AudioFormat::MPEG4AAC_HE => (kAudioFormatMPEG4AAC_HE, None),
+            AudioFormat::MPEG4AAC_LD => (kAudioFormatMPEG4AAC_LD, None),
+            AudioFormat::MPEG4AAC_ELD => (kAudioFormatMPEG4AAC_ELD, None),
+            AudioFormat::MPEG4AAC_ELD_SBR => (kAudioFormatMPEG4AAC_ELD_SBR, None),
+            AudioFormat::MPEG4AAC_ELD_V2 => (kAudioFormatMPEG4AAC_ELD_V2, None),
+            AudioFormat::MPEG4AAC_HE_V2 => (kAudioFormatMPEG4AAC_HE_V2, None),
+            AudioFormat::MPEG4AAC_Spatial => (kAudioFormatMPEG4AAC_Spatial, None),
+            AudioFormat::AMR => (kAudioFormatAMR, None),
+            AudioFormat::AMR_WB => (kAudioFormatAMR_WB, None),
+            AudioFormat::Audible => (kAudioFormatAudible, None),
+            AudioFormat::iLBC => (kAudioFormatiLBC, None),
+            AudioFormat::DVIIntelIMA => (kAudioFormatDVIIntelIMA, None),
+            AudioFormat::MicrosoftGSM => (kAudioFormatMicrosoftGSM, None),
+            AudioFormat::AES3 => (kAudioFormatAES3, None),
         }
     }
 }
@@ -286,29 +307,29 @@ bitflags! {
         /// Set for floating point, clear for integer.
         ///
         /// **Available** in OS X v10.2 and later.
-        const IS_FLOAT = 1;
+        const IS_FLOAT = kAudioFormatFlagIsFloat;
         /// Set for big endian, clear for little endian.
         ///
         /// **Available** in OS X v10.2 and later.
-        const IS_BIG_ENDIAN = 2;
+        const IS_BIG_ENDIAN = kAudioFormatFlagIsBigEndian;
         /// Set for signed integer, clear for unsigned integer.
         ///
         /// Note: This is only valid if `IS_FLOAT` is clear.
         ///
         /// **Available** in OS X v10.2 and later.
-        const IS_SIGNED_INTEGER = 4;
+        const IS_SIGNED_INTEGER = kAudioFormatFlagIsSignedInteger;
         /// Set if the sample bits occupy the entire available bits for the channel, clear if they
         /// are high- or low-aligned within the channel.
         ///
         /// **Available** in OS X v10.2 and later.
-        const IS_PACKED = 8;
+        const IS_PACKED = kAudioFormatFlagIsPacked;
         /// Set if the sample bits are placed into the high bits of the channel, clear for low bit
         /// placement.
         ///
         /// Note: This is only valid if `IS_PACKED` is clear.
         ///
         /// **Available** in OS X v10.2 and later.
-        const IS_ALIGNED_HIGH = 16;
+        const IS_ALIGNED_HIGH = kAudioFormatFlagIsAlignedHigh;
         /// Set if the sample for each channel are located contiguously and the channels are laid
         /// out end to end.
         ///
@@ -316,14 +337,14 @@ bitflags! {
         /// end to end.
         ///
         /// **Available** in OS X v10.2 and later.
-        const IS_NON_INTERLEAVED = 32;
+        const IS_NON_INTERLEAVED = kAudioFormatFlagIsNonInterleaved;
         /// Set to indicate when a format is nonmixable.
         ///
         /// Note: that this flag is only used when interacting with the HAL's stream format
         /// information. It is **not** valid for any other use.
         ///
         /// **Available** in OS X v10.3 and later.
-        const IS_NON_MIXABLE = 64;
+        const IS_NON_MIXABLE = kAudioFormatFlagIsNonMixable;
     }
 }
 
@@ -340,31 +361,31 @@ bitflags! {
         /// Synonym for the **IS_FLOAT** **StandardFlags**.
         ///
         /// **Available** in OS X v10.0 and later.
-        const IS_FLOAT = 1;
+        const IS_FLOAT = kAudioFormatFlagIsFloat;
         /// Synonym for the **IS_BIG_ENDIAN** **StandardFlags**.
         ///
         /// **Available** in OS X v10.0 and later.
-        const IS_BIG_ENDIAN = 2;
+        const IS_BIG_ENDIAN = kAudioFormatFlagIsBigEndian;
         /// Synonym for the **IS_SIGNED_INTEGER** **StandardFlags**.
         ///
         /// **Available** in OS X v10.0 and later.
-        const IS_SIGNED_INTEGER = 4;
+        const IS_SIGNED_INTEGER = kAudioFormatFlagIsSignedInteger;
         /// Synonym for the **IS_PACKED** **StandardFlags**.
         ///
         /// **Available** in OS X v10.0 and later.
-        const IS_PACKED = 8;
+        const IS_PACKED = kAudioFormatFlagIsPacked;
         /// Synonym for the **IS_ALIGNED_HIGH** **StandardFlags**.
         ///
         /// **Available** in OS X v10.0 and later.
-        const IS_ALIGNED_HIGH = 16;
+        const IS_ALIGNED_HIGH = kAudioFormatFlagIsAlignedHigh;
         /// Synonym for the **IS_NON_INTERLEAVED** **StandardFlags**.
         ///
         /// **Available** in OS X v10.2 and later.
-        const IS_NON_INTERLEAVED = 32;
+        const IS_NON_INTERLEAVED = kAudioFormatFlagIsNonInterleaved;
         /// Synonym for the **IS_NON_MIXABLE** **StandardFlags**.
         ///
         /// **Available** in OS X v10.3 and later.
-        const IS_NON_MIXABLE = 64;
+        const IS_NON_MIXABLE = kAudioFormatFlagIsNonMixable;
         /// The linear PCM flags contain a 6-bit bitfield indicating that an integer format is to
         /// be interpreted as fixed point.
         ///
@@ -378,13 +399,13 @@ bitflags! {
         /// uniquely in some way.
         ///
         /// **Available** in OS X v10.6 and later.
-        const FLAGS_SAMPLE_FRACTION_SHIFT = 7;
+        const FLAGS_SAMPLE_FRACTION_SHIFT = kLinearPCMFormatFlagsSampleFractionShift;
         /// The number of fractional bits.
         ///
         /// `== (<other_flags> & FLAGS_SAMPLE_FRACTION_MASK) >> FLAGS_SAMPLE_FRACTION_SHIFT`
         ///
         /// **Available** in OS X v10.6 and later.
-        const FLAGS_SAMPLE_FRACTION_MASK = 8064;
+        const FLAGS_SAMPLE_FRACTION_MASK = kLinearPCMFormatFlagsSampleFractionMask;
     }
 }
 
@@ -401,13 +422,13 @@ bitflags! {
     /// Original documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/AudioStreamBasicDescription_Flags).
     pub struct AppleLosslessFlags: u32 {
         /// Sourced from 16 bit native endian signed integer data.
-        const BIT_16_SOURCE_DATA = 1;
+        const BIT_16_SOURCE_DATA = kAppleLosslessFormatFlag_16BitSourceData;
         /// Sourced from 20 bit native endian signed integer data aligned high in 24 bits.
-        const BIT_20_SOURCE_DATA = 2;
+        const BIT_20_SOURCE_DATA = kAppleLosslessFormatFlag_20BitSourceData;
         /// Sourced from 24 bit native endian signed integer data.
-        const BIT_24_SOURCE_DATA = 3;
+        const BIT_24_SOURCE_DATA = kAppleLosslessFormatFlag_24BitSourceData;
         /// Sourced from 32 bit native endian signed integer data.
-        const BIT_32_SOURCE_DATA = 4;
+        const BIT_32_SOURCE_DATA = kAppleLosslessFormatFlag_32BitSourceData;
     }
 }
 
@@ -428,40 +449,42 @@ bitflags! {
 #[allow(non_camel_case_types)]
 pub enum Mpeg4ObjectId {
     /// Advanced audio coding; the baisc MPEG-4 technology.
-    AAC_Main = 1,
+    AAC_Main = Objc2MPEG4ObjectID::AAC_Main.0 as isize,
     /// Lossless coding; provides compression with no loss of quality.
-    AAC_LC = 2,
+    AAC_LC = Objc2MPEG4ObjectID::AAC_LC.0 as isize,
     /// Scalable sampling rate; provides different sampling frequencies for different targets.
-    AAC_SSR = 3,
+    AAC_SSR = Objc2MPEG4ObjectID::AAC_SSR.0 as isize,
     /// Long term prediction; reduces redundancy in a coded signal.
-    AAC_LTP = 4,
+    AAC_LTP = Objc2MPEG4ObjectID::AAC_LTP.0 as isize,
     /// Spectral band replication; reconstructs high-frequency content from lower frequencies
     /// and side information.
-    AAC_SBR = 5,
+    AAC_SBR = Objc2MPEG4ObjectID::AAC_SBR.0 as isize,
     /// Scalable lossless coding.
-    AAC_Scalable = 6,
+    AAC_Scalable = Objc2MPEG4ObjectID::AAC_Scalable.0 as isize,
     /// Transform-domain weighted interleaved vector quantization; an audio codec optimised for
     /// audio coding at ultra low bit rates around 8kbit/s.
-    TwinVQ = 7,
+    TwinVQ = Objc2MPEG4ObjectID::TwinVQ.0 as isize,
     /// Code Excited Linear Prediction; a narrow-band/wide-band speech codec.
-    CELP = 8,
+    CELP = Objc2MPEG4ObjectID::CELP.0 as isize,
     /// Harmonic Vector Excitation Coding; a very-low bit-rate parametric speech codec.
-    HVXC = 9,
+    HVXC = Objc2MPEG4ObjectID::HVXC.0 as isize,
 }
 
 impl Mpeg4ObjectId {
     /// Create an Mpeg4ObjectId from a u32.
     pub fn from_u32(u: u32) -> Option<Mpeg4ObjectId> {
         match u {
-            1 => Some(Mpeg4ObjectId::AAC_Main),
-            2 => Some(Mpeg4ObjectId::AAC_LC),
-            3 => Some(Mpeg4ObjectId::AAC_SSR),
-            4 => Some(Mpeg4ObjectId::AAC_LTP),
-            5 => Some(Mpeg4ObjectId::AAC_SBR),
-            6 => Some(Mpeg4ObjectId::AAC_Scalable),
-            7 => Some(Mpeg4ObjectId::TwinVQ),
-            8 => Some(Mpeg4ObjectId::CELP),
-            9 => Some(Mpeg4ObjectId::HVXC),
+            _ if u == Objc2MPEG4ObjectID::AAC_Main.0 as u32 => Some(Mpeg4ObjectId::AAC_Main),
+            _ if u == Objc2MPEG4ObjectID::AAC_LC.0 as u32 => Some(Mpeg4ObjectId::AAC_LC),
+            _ if u == Objc2MPEG4ObjectID::AAC_SSR.0 as u32 => Some(Mpeg4ObjectId::AAC_SSR),
+            _ if u == Objc2MPEG4ObjectID::AAC_LTP.0 as u32 => Some(Mpeg4ObjectId::AAC_LTP),
+            _ if u == Objc2MPEG4ObjectID::AAC_SBR.0 as u32 => Some(Mpeg4ObjectId::AAC_SBR),
+            _ if u == Objc2MPEG4ObjectID::AAC_Scalable.0 as u32 => {
+                Some(Mpeg4ObjectId::AAC_Scalable)
+            }
+            _ if u == Objc2MPEG4ObjectID::TwinVQ.0 as u32 => Some(Mpeg4ObjectId::TwinVQ),
+            _ if u == Objc2MPEG4ObjectID::CELP.0 as u32 => Some(Mpeg4ObjectId::CELP),
+            _ if u == Objc2MPEG4ObjectID::HVXC.0 as u32 => Some(Mpeg4ObjectId::HVXC),
             _ => None,
         }
     }
@@ -475,14 +498,14 @@ bitflags! {
     /// Original Documentation [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Reference/CoreAudioDataTypesRef/#//apple_ref/doc/constant_group/Audio_Time_Stamp_Flags).
     pub struct AudioTimeStampFlags: u32 {
         /// The sample frame time is valid.
-        const SAMPLE_TIME_VALID = 1;
+        const SAMPLE_TIME_VALID = Objc2AudioTimeStampFlags::SampleTimeValid.0;
         /// The host time is valid.
-        const HOST_TIME_VALID = 2;
+        const HOST_TIME_VALID = Objc2AudioTimeStampFlags::HostTimeValid.0;
         /// The rate scalar is valid.
-        const RATE_SCALAR_VALID = 4;
+        const RATE_SCALAR_VALID = Objc2AudioTimeStampFlags::RateScalarValid.0;
         /// The world clock time is valid.
-        const WORLD_CLOCK_TIME_VALID = 8;
+        const WORLD_CLOCK_TIME_VALID = Objc2AudioTimeStampFlags::WordClockTimeValid.0;
         /// The SMPTE time is valid.
-        const SMPTE_TIME_VALID = 16;
+        const SMPTE_TIME_VALID = Objc2AudioTimeStampFlags::SMPTETimeValid.0;
     }
 }

--- a/src/audio_unit/mod.rs
+++ b/src/audio_unit/mod.rs
@@ -20,6 +20,8 @@
 
 use objc2_audio_toolbox::{
     kAudioUnitManufacturer_Apple, kAudioUnitProperty_SampleRate, kAudioUnitProperty_StreamFormat,
+    kAudioUnitScope_Global, kAudioUnitScope_Group, kAudioUnitScope_Input, kAudioUnitScope_Layer,
+    kAudioUnitScope_LayerItem, kAudioUnitScope_Note, kAudioUnitScope_Output, kAudioUnitScope_Part,
     AudioComponentDescription, AudioComponentFindNext, AudioComponentInstanceDispose,
     AudioComponentInstanceNew, AudioOutputUnitStart, AudioOutputUnitStop,
     AudioUnit as InnerAudioUnit, AudioUnitGetProperty, AudioUnitInitialize, AudioUnitSetProperty,
@@ -54,14 +56,14 @@ pub mod types;
 /// and [here](https://developer.apple.com/library/mac/documentation/MusicAudio/Conceptual/AudioUnitProgrammingGuide/TheAudioUnit/TheAudioUnit.html).
 #[derive(Copy, Clone, Debug)]
 pub enum Scope {
-    Global = 0,
-    Input = 1,
-    Output = 2,
-    Group = 3,
-    Part = 4,
-    Note = 5,
-    Layer = 6,
-    LayerItem = 7,
+    Global = kAudioUnitScope_Global as isize,
+    Input = kAudioUnitScope_Input as isize,
+    Output = kAudioUnitScope_Output as isize,
+    Group = kAudioUnitScope_Group as isize,
+    Part = kAudioUnitScope_Part as isize,
+    Note = kAudioUnitScope_Note as isize,
+    Layer = kAudioUnitScope_Layer as isize,
+    LayerItem = kAudioUnitScope_LayerItem as isize,
 }
 
 /// Represents the **Input** and **Output** **Element**s.

--- a/src/audio_unit/render_callback.rs
+++ b/src/audio_unit/render_callback.rs
@@ -170,7 +170,7 @@ pub mod data {
 
     impl<S> NonInterleaved<S> {
         /// An iterator yielding a reference to each channel in the array.
-        pub fn channels(&self) -> Channels<S> {
+        pub fn channels(&self) -> Channels<'_, S> {
             Channels {
                 buffers: self.buffers.iter(),
                 frames: self.frames,
@@ -179,7 +179,7 @@ pub mod data {
         }
 
         /// An iterator yielding a mutable reference to each channel in the array.
-        pub fn channels_mut(&mut self) -> ChannelsMut<S> {
+        pub fn channels_mut(&mut self) -> ChannelsMut<'_, S> {
             ChannelsMut {
                 buffers: self.buffers.iter_mut(),
                 frames: self.frames,

--- a/src/audio_unit/types.rs
+++ b/src/audio_unit/types.rs
@@ -2,6 +2,32 @@
 //!
 //! Original documentation [here](https://developer.apple.com/library/prerelease/mac/documentation/AudioUnit/Reference/AUComponentServicesReference/index.html#//apple_ref/doc/constant_group/Audio_Unit_Types).
 
+#![allow(deprecated)]
+
+//#[cfg(target_os = "ios")]
+//use objc2_audio_toolbox::kAudioUnitSubType_RemoteIO;
+use objc2_audio_toolbox::{
+    kAudioUnitSubType_3DMixer, kAudioUnitSubType_AUConverter, kAudioUnitSubType_AUFilter,
+    kAudioUnitSubType_AUiPodTimeOther, kAudioUnitSubType_AudioFilePlayer,
+    kAudioUnitSubType_BandPassFilter, kAudioUnitSubType_DLSSynth, kAudioUnitSubType_DefaultOutput,
+    kAudioUnitSubType_DeferredRenderer, kAudioUnitSubType_Delay, kAudioUnitSubType_Distortion,
+    kAudioUnitSubType_DynamicsProcessor, kAudioUnitSubType_GenericOutput,
+    kAudioUnitSubType_GraphicEQ, kAudioUnitSubType_HALOutput, kAudioUnitSubType_HighPassFilter,
+    kAudioUnitSubType_HighShelfFilter, kAudioUnitSubType_LowPassFilter,
+    kAudioUnitSubType_LowShelfFilter, kAudioUnitSubType_MatrixMixer,
+    kAudioUnitSubType_MatrixReverb, kAudioUnitSubType_Merger,
+    kAudioUnitSubType_MultiBandCompressor, kAudioUnitSubType_MultiChannelMixer,
+    kAudioUnitSubType_NBandEQ, kAudioUnitSubType_NetSend, kAudioUnitSubType_NewTimePitch,
+    kAudioUnitSubType_ParametricEQ, kAudioUnitSubType_PeakLimiter, kAudioUnitSubType_Pitch,
+    kAudioUnitSubType_RogerBeep, kAudioUnitSubType_SampleDelay, kAudioUnitSubType_Sampler,
+    kAudioUnitSubType_ScheduledSoundPlayer, kAudioUnitSubType_Splitter,
+    kAudioUnitSubType_StereoMixer, kAudioUnitSubType_SystemOutput, kAudioUnitSubType_TimePitch,
+    kAudioUnitSubType_Varispeed, kAudioUnitSubType_VoiceProcessingIO, kAudioUnitType_Effect,
+    kAudioUnitType_FormatConverter, kAudioUnitType_Generator, kAudioUnitType_MIDIProcessor,
+    kAudioUnitType_Mixer, kAudioUnitType_MusicDevice, kAudioUnitType_MusicEffect,
+    kAudioUnitType_OfflineEffect, kAudioUnitType_Output, kAudioUnitType_Panner,
+};
+
 /// Represents the different kinds of Audio Units that are available.
 ///
 /// Original documentation [here](https://developer.apple.com/library/prerelease/mac/documentation/AudioUnit/Reference/AUComponentServicesReference/index.html#//apple_ref/doc/constant_group/Audio_Unit_Types).
@@ -98,16 +124,16 @@ impl Type {
     /// Convert the `Type` to its associated `u32` for compatibility with original API.
     pub fn as_u32(&self) -> u32 {
         match *self {
-            Type::IO(_) => 1635086197,
-            Type::MusicDevice(_) => 1635085685,
-            Type::MusicEffect => 1635085670,
-            Type::FormatConverter(_) => 1635083875,
-            Type::Effect(_) => 1635083896,
-            Type::Mixer(_) => 1635085688,
-            Type::Panner => 1635086446,
-            Type::Generator(_) => 1635084142,
-            Type::OfflineEffect => 1635086188,
-            Type::MidiProcessor => 1635085673,
+            Type::IO(_) => kAudioUnitType_Output,
+            Type::MusicDevice(_) => kAudioUnitType_MusicDevice,
+            Type::MusicEffect => kAudioUnitType_MusicEffect,
+            Type::FormatConverter(_) => kAudioUnitType_FormatConverter,
+            Type::Effect(_) => kAudioUnitType_Effect,
+            Type::Mixer(_) => kAudioUnitType_Mixer,
+            Type::Panner => kAudioUnitType_Panner,
+            Type::Generator(_) => kAudioUnitType_Generator,
+            Type::OfflineEffect => kAudioUnitType_OfflineEffect,
+            Type::MidiProcessor => kAudioUnitType_MIDIProcessor,
         }
     }
 
@@ -167,89 +193,89 @@ pub enum EffectType {
     /// An audio unit that enforces an upper dynamic limit on an audio signal.
     ///
     /// **Available** in OS X v10.2 and later.
-    PeakLimiter = 1819112562,
+    PeakLimiter = kAudioUnitSubType_PeakLimiter as isize,
     /// An audio unit that provides dynamic compression or expansion.
     ///
     /// **Available** in OS X v10.3 and later.
-    DynamicsProcessor = 1684237680,
+    DynamicsProcessor = kAudioUnitSubType_DynamicsProcessor as isize,
     /// An audio unit that passes frequencies below a specified cutoff frequency and blocks
     /// frequencies above that cutoff frequency.
     ///
     /// **Available** in OS X v10.2 and later.
-    LowPassFilter = 1819304307,
+    LowPassFilter = kAudioUnitSubType_LowPassFilter as isize,
     /// An audio unit that passes frequencies above a specified cutoff frequency and blocks
     /// frequencies below that cutoff frequency.
     ///
     /// **Available** in OS X v10.2 and later.
-    HighPassFilter = 1752195443,
+    HighPassFilter = kAudioUnitSubType_HighPassFilter as isize,
     /// An audio unit that passes frequencies between specified upper and lower cutoff frequencies,
     /// and blocks frequencies outside that band.
     ///
     /// **Available** in OS X v10.2 and later.
-    BandPassFilter = 1651532147,
+    BandPassFilter = kAudioUnitSubType_BandPassFilter as isize,
     /// An audio unit suitable for implementing a treble control in an audio playback or recording
     /// system.
     ///
     /// **Available** in OS X v10.2 and later.
-    HighShelfFilter = 1752393830,
+    HighShelfFilter = kAudioUnitSubType_HighShelfFilter as isize,
     /// An audio unit suitable for implementing a bass control in an audio playback or recording
     /// system.
     ///
     /// **Available** in OS X v10.2 and later.
-    LowShelfFilter = 1819502694,
+    LowShelfFilter = kAudioUnitSubType_LowShelfFilter as isize,
     /// An audio unit that provides a filter whose center frequency, boost/cut level, and Q can be
     /// adjusted.
     ///
     /// **Available** in OS X v10.2 and later.
-    ParametricEQ = 1886217585,
+    ParametricEQ = kAudioUnitSubType_ParametricEQ as isize,
     /// An audio unit that provides a distortion effect.
     ///
     /// **Available** in OS X v10.5 and later.
-    Distortion = 1684632436,
+    Distortion = kAudioUnitSubType_Distortion as isize,
     /// An audio unit that introduces a time delay to a signal.
     ///
     /// **Available** in OS X v10.2 and later.
-    Delay = 1684368505,
+    Delay = kAudioUnitSubType_Delay as isize,
     /// An audio unit that provides a time delay for a specified number of samples.
     ///
     /// **Available** in OS X v10.4 and later.
-    SampleDelay = 1935961209,
+    SampleDelay = kAudioUnitSubType_SampleDelay as isize,
     /// An audio unit that provides a 10- or 31-band graphic equalizer.
     ///
     /// Available in OS X v10.2 and later.
-    GraphicEQ = 1735550321,
+    GraphicEQ = kAudioUnitSubType_GraphicEQ as isize,
     /// An audio unit that provides four-bands of dynamic compression or expansion.
     ///
     /// **Available** in OS X v10.3 and later.
-    MultiBandCompressor = 1835232624,
+    MultiBandCompressor = kAudioUnitSubType_MultiBandCompressor as isize,
     /// An audio unit that provides a reverberation effect that can be used to simulate a variety
     /// of acoustic spaces.
     ///
     /// **Available** in OS X v10.2 and later.
-    MatrixReverb = 1836213622,
+    MatrixReverb = kAudioUnitSubType_MatrixReverb as isize,
     /// An audio unit for modifying the pitch of a signal.
     ///
     /// **Available** in OS X v10.4 and later.
-    Pitch = 1953329268,
+    Pitch = kAudioUnitSubType_Pitch as isize,
     /// An audio unit that provides a combination of five filters: low-frequency, three
     /// mid-frequencies, and high-frequency.
     ///
     /// **Available** in OS X v10.4 and later.
-    AUFilter = 1718185076,
+    AUFilter = kAudioUnitSubType_AUFilter as isize,
     /// An audio unit for use in conjunction with a kAudioUnitSubType_NetReceive audio unit for
     /// sending audio across a network or from one application to another.
     ///
     /// **Available** in OS X v10.4 and later.
-    NetSend = 1853058660,
+    NetSend = kAudioUnitSubType_NetSend as isize,
     /// An audio unit that detects gaps between segments of speech and fills the gaps with a short
     /// tone, simulating the sound of a walkie-talkie communication device.
     ///
     /// **Available** in OS X v10.5 and later.
-    RogerBeep = 1919903602,
+    RogerBeep = kAudioUnitSubType_RogerBeep as isize,
     /// A multi-band equalizer with specifiable filter type for each band.
     ///
     /// **Available** in OS X v10.9 and later.
-    NBandEQ = 1851942257,
+    NBandEQ = kAudioUnitSubType_NBandEQ as isize,
 }
 
 /// Audio data format converter audio unit subtypes for **AudioUnit**s provided by Apple.
@@ -259,7 +285,7 @@ pub enum FormatConverterType {
     /// sample rate, bit depth, or interleaving.
     ///
     /// **Available** in OS X v10.2 and later.
-    AUConverter = 1668247158,
+    AUConverter = kAudioUnitSubType_AUConverter as isize,
     /// An audio unit that can be used to have independent control of both playback rate and pitch.
     ///
     /// In OS X it provides a generic view, so it can be used in both a UI and programmatic
@@ -268,13 +294,13 @@ pub enum FormatConverterType {
     /// It also comes in an offline version for processing audio files.
     ///
     /// **Available** in OS X v10.7 and later.
-    NewTimePitch = 1853191280,
+    NewTimePitch = kAudioUnitSubType_NewTimePitch as isize,
     /// An audio unit that can provide independent control of playback rate and pitch. This subtype
     /// provides a generic view, making it suitable for UI and programmatic context. OS X provides
     /// realtime and offline audio units of this subtype.
     ///
     /// **Available** in OS X v10.3 and later.
-    TimePitch = 1953329268,
+    TimePitch = kAudioUnitSubType_TimePitch as isize,
     /// An audio unit that acquires audio input from a separate thread than the thread on which its
     /// render method is called.
     ///
@@ -283,17 +309,17 @@ pub enum FormatConverterType {
     /// There is a delay, equal to the buffer size, introduced between the audio input and output.
     ///
     /// **Available** in OS X v10.4 and later.
-    DeferredRenderer = 1684366962,
+    DeferredRenderer = kAudioUnitSubType_DeferredRenderer as isize,
     /// An audio unit with one input bus and two output buses. The audio unit duplicates the input
     /// signal to each of its two output buses.
     ///
     /// **Available** in OS X v10.4 and later.
-    Splitter = 1936747636,
+    Splitter = kAudioUnitSubType_Splitter as isize,
     /// An audio unit with two input buses and one output bus. The audio unit merges the two input
     /// signals to the single output.
     ///
     /// **Available** in OS X v10.4 and later.
-    Merger = 1835364967,
+    Merger = kAudioUnitSubType_Merger as isize,
     /// An audio unit that can control playback rate. As the playback rate increases, so does
     /// pitch.
     ///
@@ -302,9 +328,9 @@ pub enum FormatConverterType {
     /// OS X provides realtime and offline audio units of this subtype.
     ///
     /// **Available** in OS X v10.3 and later.
-    Varispeed = 1986097769,
+    Varispeed = kAudioUnitSubType_Varispeed as isize,
     /// **Available** in OS X v10.9 and later.
-    AUiPodTimeOther = 1768977519,
+    AUiPodTimeOther = kAudioUnitSubType_AUiPodTimeOther as isize,
 }
 
 /// Audio mixing **AudioUnit** subtypes for **AudioUnit**s provided by Apple.
@@ -318,12 +344,12 @@ pub enum MixerType {
     /// In iPhone OS, the output bus always has two channels.
     ///
     /// **Available** in OS X v10.5 and later.
-    MultiChannelMixer = 1835232632,
+    MultiChannelMixer = kAudioUnitSubType_MultiChannelMixer as isize,
     /// An audio unit that can have any number of input buses, each of which is mono or stereo, and
     /// one stereo output bus.
     ///
     /// **Available** in OS X v10.2 and later.
-    StereoMixer = 1936554098,
+    StereoMixer = kAudioUnitSubType_StereoMixer as isize,
     /// An audio unit that can have any number of input buses and one output bus.
     ///
     /// Each input bus can be mono, in which case it can be panned using 3D coordinates and
@@ -338,7 +364,8 @@ pub enum MixerType {
     /// **Available** in OS X v10.3 and later.
     ///
     /// **Deprecated** in OS X v10.10.
-    Mixer3D = 862219640,
+    #[deprecated = "Depecated in OS X v10.10"]
+    Mixer3D = kAudioUnitSubType_3DMixer as isize,
     /// An audio unit that can have any number of input and output buses with any number of
     /// channels on each bus.
     ///
@@ -352,7 +379,7 @@ pub enum MixerType {
     /// Finally, the audio unit provides a global level control for the matrix as a whole.
     ///
     /// **Available** in OS X v10.3 and later.
-    MatrixMixer = 1836608888,
+    MatrixMixer = kAudioUnitSubType_MatrixMixer as isize,
 }
 
 /// Audio units that serve as sound sources.
@@ -365,12 +392,12 @@ pub enum GeneratorType {
     /// from any thread.
     ///
     /// **Available** in OS X v10.4 and later.
-    ScheduledSoundPlayer = 1936945260,
+    ScheduledSoundPlayer = kAudioUnitSubType_ScheduledSoundPlayer as isize,
     /// A generator unit that is used to play a file. In OS X it presents a custom UI so can be
     /// used in a UI context as well as in a programmatic context.
     ///
     /// **Available** in OS X v10.4 and later.
-    AudioFilePlayer = 1634103404,
+    AudioFilePlayer = kAudioUnitSubType_AudioFilePlayer as isize,
 }
 
 /// Audio units that can be played as musical instruments via MIDI control.
@@ -382,12 +409,12 @@ pub enum MusicDeviceType {
     /// It fully supports GM-MIDI and the basic extensions of GS-MIDI
     ///
     /// **Available** in OS X v10.2 and later.
-    DLSSynth = 1684828960,
+    DLSSynth = kAudioUnitSubType_DLSSynth as isize,
     /// A monotimbral instrument unit that functions a a sampler-synthesizer and supports full
     /// interactive editing of its state.
     ///
     /// **Available** in OS X v10.7 and later.
-    Sampler = 1935764848,
+    Sampler = kAudioUnitSubType_Sampler as isize,
 }
 
 /// Input/output **AudioUnit** subtypes for **AudioUnit**s provided by Apple.
@@ -407,23 +434,23 @@ pub enum IOType {
     /// a parent audio processing graph.
     ///
     /// **Available** in OS X v10.2 and later.
-    GenericOutput = 1734700658,
+    GenericOutput = kAudioUnitSubType_GenericOutput as isize,
     /// An audio unit that can provides input/output connection to an a specified audio device.
     ///
     /// Bus 0 provides output to the audio device and bus 1 accepts input from the audio device.
     ///
     /// **Available** in OS X v10.2 and later.
-    HalOutput = 1634230636,
+    HalOutput = kAudioUnitSubType_HALOutput as isize,
     /// A specialized **HalOutput** audio unit that connects to the user’s selected default device
     /// in Sound Preferences.
     ///
     /// **Available** in OS X v10.2 and later.
-    DefaultOutput = 1684366880,
+    DefaultOutput = kAudioUnitSubType_DefaultOutput as isize,
     /// A specialized **HalOutput** audio unit that connects to the user’s selected device for
     /// sound effects, alerts, and other user-interface sounds.
     ///
     /// **Available** in OS X v10.2 and later.
-    SystemOutput = 1937339168,
+    SystemOutput = kAudioUnitSubType_SystemOutput as isize,
     /// An audio unit that interfaces to the audio inputs and outputs of iPhone OS devices and
     /// provides voice processing features.
     ///
@@ -434,12 +461,13 @@ pub enum IOType {
     /// enumeration for the identifiers for this audio unit’s properties.
     ///
     /// **Available** in OS X v10.7 and later.
-    VoiceProcessingIO = 1987078511,
+    VoiceProcessingIO = kAudioUnitSubType_VoiceProcessingIO as isize,
     /// Connects to device hardware for input, output, or simultaneous input and output.
     /// Use it for playback, recording, or low-latency simultaneous input and output where echo
     /// cancellation is not needed.
     ///
     /// See <https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/AudioUnitHostingGuide_iOS/UsingSpecificAudioUnits/UsingSpecificAudioUnits.html>
     /// **Available** in iOS.
-    RemoteIO = 1919512419,
+    #[cfg(target_os = "ios")]
+    RemoteIO = 1919512419, //kAudioUnitSubType_RemoteIO, only available in the ios sdk,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,18 +6,27 @@ pub use self::audio_format::Error as AudioFormatError;
 pub use self::audio_unit::Error as AudioUnitError;
 use crate::OSStatus;
 
+use objc2_audio_toolbox::{
+    kAudioServicesSystemSoundClientTimedOutError, kAudioServicesSystemSoundUnspecifiedError,
+};
+
 pub mod audio {
     use crate::OSStatus;
+    use objc2_core_audio_types::{
+        kAudio_BadFilePathError, kAudio_FileNotFoundError, kAudio_FilePermissionError,
+        kAudio_MemFullError, kAudio_ParamError, kAudio_TooManyFilesOpenError,
+        kAudio_UnimplementedError,
+    };
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
-        Unimplemented = -4,
-        FileNotFound = -43,
-        FilePermission = -54,
-        TooManyFilesOpen = -42,
-        BadFilePath = 561017960,
-        Param = -50,
-        MemFull = -108,
+        Unimplemented = kAudio_UnimplementedError as isize,
+        FileNotFound = kAudio_FileNotFoundError as isize,
+        FilePermission = kAudio_FilePermissionError as isize,
+        TooManyFilesOpen = kAudio_TooManyFilesOpenError as isize,
+        BadFilePath = kAudio_BadFilePathError as isize,
+        Param = kAudio_ParamError as isize,
+        MemFull = kAudio_MemFullError as isize,
         Unknown,
     }
 
@@ -25,13 +34,13 @@ pub mod audio {
         pub fn from_os_status(os_status: OSStatus) -> Result<(), Error> {
             match os_status {
                 0 => Ok(()),
-                -4 => Err(Error::Unimplemented),
-                -43 => Err(Error::FileNotFound),
-                -54 => Err(Error::FilePermission),
-                -42 => Err(Error::TooManyFilesOpen),
-                561017960 => Err(Error::BadFilePath),
-                -50 => Err(Error::Param),
-                -108 => Err(Error::MemFull),
+                _ if os_status == kAudio_UnimplementedError => Err(Error::Unimplemented),
+                _ if os_status == kAudio_FileNotFoundError => Err(Error::FileNotFound),
+                _ if os_status == kAudio_FilePermissionError => Err(Error::FilePermission),
+                _ if os_status == kAudio_TooManyFilesOpenError => Err(Error::TooManyFilesOpen),
+                _ if os_status == kAudio_BadFilePathError => Err(Error::BadFilePath),
+                _ if os_status == kAudio_ParamError => Err(Error::Param),
+                _ if os_status == kAudio_MemFullError => Err(Error::MemFull),
                 _ => Err(Error::Unknown),
             }
         }
@@ -62,16 +71,23 @@ pub mod audio {
 
 pub mod audio_codec {
     use crate::OSStatus;
+    use objc2_audio_toolbox::{
+        kAudioCodecBadDataError, kAudioCodecBadPropertySizeError, kAudioCodecIllegalOperationError,
+        kAudioCodecNotEnoughBufferSpaceError, kAudioCodecStateError,
+        kAudioCodecUnknownPropertyError, kAudioCodecUnspecifiedError,
+        kAudioCodecUnsupportedFormatError,
+    };
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
-        Unspecified = 2003329396,
-        UnknownProperty = 2003332927,
-        BadPropertySize = 561211770,
-        IllegalOperation = 1852797029,
-        UnsupportedFormat = 560226676,
-        State = 561214580,
-        NotEnoughBufferSpace = 560100710,
+        Unspecified = kAudioCodecUnspecifiedError as isize,
+        UnknownProperty = kAudioCodecUnknownPropertyError as isize,
+        BadPropertySize = kAudioCodecBadPropertySizeError as isize,
+        IllegalOperation = kAudioCodecIllegalOperationError as isize,
+        UnsupportedFormat = kAudioCodecUnsupportedFormatError as isize,
+        State = kAudioCodecStateError as isize,
+        NotEnoughBufferSpace = kAudioCodecNotEnoughBufferSpaceError as isize,
+        BadData = kAudioCodecBadDataError as isize,
         Unknown,
     }
 
@@ -79,13 +95,18 @@ pub mod audio_codec {
         pub fn from_os_status(os_status: OSStatus) -> Result<(), Error> {
             match os_status {
                 0 => Ok(()),
-                2003329396 => Err(Error::Unspecified),
-                2003332927 => Err(Error::UnknownProperty),
-                561211770 => Err(Error::BadPropertySize),
-                1852797029 => Err(Error::IllegalOperation),
-                560226676 => Err(Error::UnsupportedFormat),
-                561214580 => Err(Error::State),
-                560100710 => Err(Error::NotEnoughBufferSpace),
+                _ if os_status == kAudioCodecUnspecifiedError => Err(Error::Unspecified),
+                _ if os_status == kAudioCodecUnknownPropertyError => Err(Error::UnknownProperty),
+                _ if os_status == kAudioCodecBadPropertySizeError => Err(Error::BadPropertySize),
+                _ if os_status == kAudioCodecIllegalOperationError => Err(Error::IllegalOperation),
+                _ if os_status == kAudioCodecUnsupportedFormatError => {
+                    Err(Error::UnsupportedFormat)
+                }
+                _ if os_status == kAudioCodecStateError => Err(Error::State),
+                _ if os_status == kAudioCodecNotEnoughBufferSpaceError => {
+                    Err(Error::NotEnoughBufferSpace)
+                }
+                _ if os_status == kAudioCodecBadDataError => Err(Error::BadData),
                 _ => Err(Error::Unknown),
             }
         }
@@ -107,6 +128,7 @@ pub mod audio_codec {
                 Error::UnsupportedFormat => "Unsupported format",
                 Error::State => "State",
                 Error::NotEnoughBufferSpace => "Not enough buffer space",
+                Error::BadData => "Bad data",
                 Error::Unknown => "Unknown error occurred",
             };
             write!(f, "{description}")
@@ -116,24 +138,38 @@ pub mod audio_codec {
 
 pub mod audio_format {
     use crate::OSStatus;
+    use objc2_audio_toolbox::{
+        kAudioFormatBadPropertySizeError, kAudioFormatBadSpecifierSizeError,
+        kAudioFormatUnknownFormatError, kAudioFormatUnspecifiedError,
+        kAudioFormatUnsupportedDataFormatError, kAudioFormatUnsupportedPropertyError,
+    };
 
     // TODO: Finish implementing these values.
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
-        Unspecified,                        // 'what'
-        UnsupportedProperty,                // 'prop'
-        BadPropertySize,                    // '!siz'
-        BadSpecifierSize,                   // '!spc'
-        UnsupportedDataFormat = 1718449215, // 'fmt?'
-        UnknownFormat,                      // '!fmt'
-        Unknown,                            //
+        Unspecified = kAudioFormatUnspecifiedError as isize,
+        UnsupportedProperty = kAudioFormatUnsupportedPropertyError as isize,
+        BadPropertySize = kAudioFormatBadPropertySizeError as isize,
+        BadSpecifierSize = kAudioFormatBadSpecifierSizeError as isize,
+        UnsupportedDataFormat = kAudioFormatUnsupportedDataFormatError as isize,
+        UnknownFormat = kAudioFormatUnknownFormatError as isize,
+        Unknown,
     }
 
     impl Error {
         pub fn from_os_status(os_status: OSStatus) -> Result<(), Error> {
             match os_status {
                 0 => Ok(()),
-                1718449215 => Err(Error::UnsupportedDataFormat),
+                _ if os_status == kAudioFormatUnspecifiedError => Err(Error::Unspecified),
+                _ if os_status == kAudioFormatUnsupportedPropertyError => {
+                    Err(Error::UnsupportedProperty)
+                }
+                _ if os_status == kAudioFormatBadPropertySizeError => Err(Error::BadPropertySize),
+                _ if os_status == kAudioFormatBadSpecifierSizeError => Err(Error::BadSpecifierSize),
+                _ if os_status == kAudioFormatUnsupportedDataFormatError => {
+                    Err(Error::UnsupportedDataFormat)
+                }
+                _ if os_status == kAudioFormatUnknownFormatError => Err(Error::UnknownFormat),
                 _ => Err(Error::Unknown),
             }
         }
@@ -163,49 +199,73 @@ pub mod audio_format {
 
 pub mod audio_unit {
     use crate::OSStatus;
+    use objc2_audio_toolbox::{
+        kAudioUnitErr_CannotDoInCurrentContext, kAudioUnitErr_FailedInitialization,
+        kAudioUnitErr_FormatNotSupported, kAudioUnitErr_Initialized, kAudioUnitErr_InvalidElement,
+        kAudioUnitErr_InvalidFile, kAudioUnitErr_InvalidOfflineRender,
+        kAudioUnitErr_InvalidParameter, kAudioUnitErr_InvalidProperty,
+        kAudioUnitErr_InvalidPropertyValue, kAudioUnitErr_InvalidScope, kAudioUnitErr_NoConnection,
+        kAudioUnitErr_PropertyNotInUse, kAudioUnitErr_PropertyNotWritable,
+        kAudioUnitErr_TooManyFramesToProcess, kAudioUnitErr_Unauthorized,
+        kAudioUnitErr_Uninitialized,
+    };
 
     #[derive(Copy, Clone, Debug)]
     pub enum Error {
-        InvalidProperty = -10879,
-        InvalidParameter = -10878,
-        InvalidElement = -10877,
-        NoConnection = -10876,
-        FailedInitialization = -10875,
-        TooManyFramesToProcess = -10874,
-        InvalidFile = -10871,
-        FormatNotSupported = -10868,
-        Uninitialized = -10867,
-        InvalidScope = -10866,
-        PropertyNotWritable = -10865,
-        CannotDoInCurrentContext = -10863,
-        InvalidPropertyValue = -10851,
-        PropertyNotInUse = -10850,
-        Initialized = -10849,
-        InvalidOfflineRender = -10848,
-        Unauthorized = -10847,
+        InvalidProperty = kAudioUnitErr_InvalidProperty as isize,
+        InvalidParameter = kAudioUnitErr_InvalidParameter as isize,
+        InvalidElement = kAudioUnitErr_InvalidElement as isize,
+        NoConnection = kAudioUnitErr_NoConnection as isize,
+        FailedInitialization = kAudioUnitErr_FailedInitialization as isize,
+        TooManyFramesToProcess = kAudioUnitErr_TooManyFramesToProcess as isize,
+        InvalidFile = kAudioUnitErr_InvalidFile as isize,
+        FormatNotSupported = kAudioUnitErr_FormatNotSupported as isize,
+        Uninitialized = kAudioUnitErr_Uninitialized as isize,
+        InvalidScope = kAudioUnitErr_InvalidScope as isize,
+        PropertyNotWritable = kAudioUnitErr_PropertyNotWritable as isize,
+        CannotDoInCurrentContext = kAudioUnitErr_CannotDoInCurrentContext as isize,
+        InvalidPropertyValue = kAudioUnitErr_InvalidPropertyValue as isize,
+        PropertyNotInUse = kAudioUnitErr_PropertyNotInUse as isize,
+        Initialized = kAudioUnitErr_Initialized as isize,
+        InvalidOfflineRender = kAudioUnitErr_InvalidOfflineRender as isize,
+        Unauthorized = kAudioUnitErr_Unauthorized as isize,
         Unknown,
     }
 
     impl Error {
         pub fn from_os_status(os_status: OSStatus) -> Result<(), Error> {
             match os_status {
-                -10879 => Err(Error::InvalidProperty),
-                -10878 => Err(Error::InvalidParameter),
-                -10877 => Err(Error::InvalidElement),
-                -10876 => Err(Error::NoConnection),
-                -10875 => Err(Error::FailedInitialization),
-                -10874 => Err(Error::TooManyFramesToProcess),
-                -10871 => Err(Error::InvalidFile),
-                -10868 => Err(Error::FormatNotSupported),
-                -10867 => Err(Error::Uninitialized),
-                -10866 => Err(Error::InvalidScope),
-                -10865 => Err(Error::PropertyNotWritable),
-                -10863 => Err(Error::CannotDoInCurrentContext),
-                -10851 => Err(Error::InvalidPropertyValue),
-                -10850 => Err(Error::PropertyNotInUse),
-                -10849 => Err(Error::Initialized),
-                -10848 => Err(Error::InvalidOfflineRender),
-                -10847 => Err(Error::Unauthorized),
+                _ if os_status == kAudioUnitErr_InvalidProperty => Err(Error::InvalidProperty),
+                _ if os_status == kAudioUnitErr_InvalidParameter => Err(Error::InvalidParameter),
+                _ if os_status == kAudioUnitErr_InvalidElement => Err(Error::InvalidElement),
+                _ if os_status == kAudioUnitErr_NoConnection => Err(Error::NoConnection),
+                _ if os_status == kAudioUnitErr_FailedInitialization => {
+                    Err(Error::FailedInitialization)
+                }
+                _ if os_status == kAudioUnitErr_TooManyFramesToProcess => {
+                    Err(Error::TooManyFramesToProcess)
+                }
+                _ if os_status == kAudioUnitErr_InvalidFile => Err(Error::InvalidFile),
+                _ if os_status == kAudioUnitErr_FormatNotSupported => {
+                    Err(Error::FormatNotSupported)
+                }
+                _ if os_status == kAudioUnitErr_Uninitialized => Err(Error::Uninitialized),
+                _ if os_status == kAudioUnitErr_InvalidScope => Err(Error::InvalidScope),
+                _ if os_status == kAudioUnitErr_PropertyNotWritable => {
+                    Err(Error::PropertyNotWritable)
+                }
+                _ if os_status == kAudioUnitErr_CannotDoInCurrentContext => {
+                    Err(Error::CannotDoInCurrentContext)
+                }
+                _ if os_status == kAudioUnitErr_InvalidPropertyValue => {
+                    Err(Error::InvalidPropertyValue)
+                }
+                _ if os_status == kAudioUnitErr_PropertyNotInUse => Err(Error::PropertyNotInUse),
+                _ if os_status == kAudioUnitErr_Initialized => Err(Error::Initialized),
+                _ if os_status == kAudioUnitErr_InvalidOfflineRender => {
+                    Err(Error::InvalidOfflineRender)
+                }
+                _ if os_status == kAudioUnitErr_Unauthorized => Err(Error::Unauthorized),
                 _ => Err(Error::Unknown),
             }
         }
@@ -267,8 +327,10 @@ impl Error {
     pub fn from_os_status(os_status: OSStatus) -> Result<(), Error> {
         match os_status {
             0 => Ok(()),
-            -1500 => Err(Error::Unspecified),
-            -1501 => Err(Error::SystemSoundClientMessageTimedOut),
+            _ if os_status == kAudioServicesSystemSoundUnspecifiedError => Err(Error::Unspecified),
+            _ if os_status == kAudioServicesSystemSoundClientTimedOutError => {
+                Err(Error::SystemSoundClientMessageTimedOut)
+            }
             _ => {
                 match AudioError::from_os_status(os_status) {
                     Ok(()) => return Ok(()),
@@ -298,14 +360,16 @@ impl Error {
     /// Convert an Error to an OSStatus.
     pub fn as_os_status(&self) -> OSStatus {
         match *self {
-            Error::Unspecified => -1500,
-            Error::NoMatchingDefaultAudioUnitFound => -1500,
-            Error::RenderCallbackBufferFormatDoesNotMatchAudioUnitStreamFormat => -1500,
-            Error::SystemSoundClientMessageTimedOut => -1501,
+            Error::Unspecified => kAudioServicesSystemSoundUnspecifiedError,
+            Error::NoMatchingDefaultAudioUnitFound => kAudioServicesSystemSoundUnspecifiedError,
+            Error::RenderCallbackBufferFormatDoesNotMatchAudioUnitStreamFormat => {
+                kAudioServicesSystemSoundUnspecifiedError
+            }
+            Error::SystemSoundClientMessageTimedOut => kAudioServicesSystemSoundClientTimedOutError,
             Error::Audio(err) => err as OSStatus,
             Error::AudioCodec(err) => err as OSStatus,
             Error::AudioUnit(err) => err as OSStatus,
-            _ => -1500,
+            _ => kAudioServicesSystemSoundUnspecifiedError,
         }
     }
 }


### PR DESCRIPTION
This library uses quite a few constants, for audio unit types, errors, etc etc. Currently, they are defined directly in the core audio-rs code. But their original definitions are in the sdk headers, and that means they are available in the objc2 crates.

This PR removes all the constant defined in this library, and instead imports them from objc2. This way there Is much less risk for typos, and if there is a typo is much easier to spot. The only exception is the kAudioUnitSubType_RemoteIO subtype which only exists in the iOS sdk. I have not managed to figure out how to import it, so I left this one as it was.

The api almost doesn't change. Only one missing BadData error is added, and some incomplete mapping between os status and error is fixed. 