### PR TITLE
feat: add get_available_sample_rates and get_device_transport_type helpers

### DIFF
--- a/src/audio_unit/macos_helpers.rs
+++ b/src/audio_unit/macos_helpers.rs
@@ -641,18 +641,18 @@ pub fn get_available_sample_rates(device_id: AudioDeviceID) -> Result<Vec<AudioV
     // SAFETY: AudioObjectGetPropertyData writes exactly n_ranges elements
     // (validated by data_size from the previous call) into the pre-allocated
     // buffer. AudioValueRange is a plain C struct with no drop semantics.
-    unsafe {
+    let status = unsafe {
         ranges.set_len(n_ranges);
-        let status = AudioObjectGetPropertyData(
+        AudioObjectGetPropertyData(
             device_id,
             NonNull::from(&property_address),
             0,
             null(),
             NonNull::from(&data_size),
             NonNull::new(ranges.as_mut_ptr()).unwrap().cast(),
-        );
-        Error::from_os_status(status)?;
-    }
+        )
+    };
+    Error::from_os_status(status)?;
     Ok(ranges)
 }
 

--- a/src/audio_unit/macos_helpers.rs
+++ b/src/audio_unit/macos_helpers.rs
@@ -18,11 +18,12 @@ use objc2_core_audio::{
     kAudioDevicePropertyAvailableNominalSampleRates, kAudioDevicePropertyDeviceIsAlive,
     kAudioDevicePropertyDeviceNameCFString, kAudioDevicePropertyHogMode,
     kAudioDevicePropertyNominalSampleRate, kAudioDevicePropertyScopeOutput,
-    kAudioDevicePropertyStreamConfiguration, kAudioHardwareNoError,
-    kAudioHardwarePropertyDefaultInputDevice, kAudioHardwarePropertyDefaultOutputDevice,
-    kAudioHardwarePropertyDevices, kAudioObjectPropertyElementMaster,
-    kAudioObjectPropertyElementWildcard, kAudioObjectPropertyScopeGlobal,
-    kAudioObjectPropertyScopeInput, kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
+    kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyTransportType,
+    kAudioHardwareNoError, kAudioHardwarePropertyDefaultInputDevice,
+    kAudioHardwarePropertyDefaultOutputDevice, kAudioHardwarePropertyDevices,
+    kAudioObjectPropertyElementMaster, kAudioObjectPropertyElementWildcard,
+    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput,
+    kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
     kAudioStreamPropertyAvailablePhysicalFormats, kAudioStreamPropertyPhysicalFormat,
     AudioDeviceID, AudioObjectAddPropertyListener, AudioObjectGetPropertyData,
     AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
@@ -186,6 +187,28 @@ pub fn get_audio_device_ids() -> Result<Vec<AudioDeviceID>, Error> {
 #[test]
 fn test_get_audio_device_ids() {
     let _ = get_audio_device_ids().expect("Failed to get audio device ids");
+}
+
+#[test]
+fn test_get_available_sample_rates() {
+    if let Some(device_id) = get_default_device_id(false) {
+        let rates = get_available_sample_rates(device_id).expect("Failed to get sample rates");
+        assert!(!rates.is_empty(), "Default output device should support at least one sample rate");
+        for range in &rates {
+            assert!(range.mMinimum > 0.0, "Sample rate minimum should be positive");
+            assert!(range.mMaximum >= range.mMinimum, "Maximum should be >= minimum");
+        }
+    }
+}
+
+#[test]
+fn test_get_device_transport_type() {
+    if let Some(device_id) = get_default_device_id(false) {
+        let transport = get_device_transport_type(device_id).expect("Failed to get transport type");
+        // Transport type should be a non-zero FourCC value (or 0 for unknown)
+        // The default output device typically has a known transport type
+        let _ = transport;
+    }
 }
 
 #[test]
@@ -575,6 +598,76 @@ pub fn get_supported_physical_stream_formats(
         formats
     };
     Ok(allformats)
+}
+
+/// Get the available nominal sample rate ranges for a device.
+///
+/// Returns a vector of [`AudioValueRange`] where each entry describes a supported range.
+/// For devices that support discrete rates, `mMinimum` and `mMaximum` will be equal.
+/// For devices that support continuous ranges, they will differ.
+pub fn get_available_sample_rates(
+    device_id: AudioDeviceID,
+) -> Result<Vec<AudioValueRange>, Error> {
+    let property_address = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyAvailableNominalSampleRates,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+
+    unsafe {
+        let mut data_size = 0u32;
+        let status = AudioObjectGetPropertyDataSize(
+            device_id,
+            NonNull::from(&property_address),
+            0,
+            null(),
+            NonNull::from(&mut data_size),
+        );
+        Error::from_os_status(status)?;
+
+        let n_ranges = data_size as usize / mem::size_of::<AudioValueRange>();
+        let mut ranges: Vec<AudioValueRange> = vec![];
+        ranges.reserve_exact(n_ranges);
+        ranges.set_len(n_ranges);
+
+        let status = AudioObjectGetPropertyData(
+            device_id,
+            NonNull::from(&property_address),
+            0,
+            null(),
+            NonNull::from(&data_size),
+            NonNull::new(ranges.as_mut_ptr()).unwrap().cast(),
+        );
+        Error::from_os_status(status)?;
+        Ok(ranges)
+    }
+}
+
+/// Get the transport type of a device.
+///
+/// The returned value is one of the `kAudioDeviceTransportType*` constants
+/// (e.g. `kAudioDeviceTransportTypeUSB`, `kAudioDeviceTransportTypeBuiltIn`).
+pub fn get_device_transport_type(device_id: AudioDeviceID) -> Result<u32, Error> {
+    let property_address = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyTransportType,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+
+    unsafe {
+        let mut transport_type: u32 = 0;
+        let data_size = mem::size_of::<u32>() as u32;
+        let status = AudioObjectGetPropertyData(
+            device_id,
+            NonNull::from(&property_address),
+            0,
+            null(),
+            NonNull::from(&data_size),
+            NonNull::from(&mut transport_type).cast(),
+        );
+        Error::from_os_status(status)?;
+        Ok(transport_type)
+    }
 }
 
 /// Changing the sample rate is an asynchronous process.

--- a/src/audio_unit/macos_helpers.rs
+++ b/src/audio_unit/macos_helpers.rs
@@ -193,10 +193,19 @@ fn test_get_audio_device_ids() {
 fn test_get_available_sample_rates() {
     if let Some(device_id) = get_default_device_id(false) {
         let rates = get_available_sample_rates(device_id).expect("Failed to get sample rates");
-        assert!(!rates.is_empty(), "Default output device should support at least one sample rate");
+        assert!(
+            !rates.is_empty(),
+            "Default output device should support at least one sample rate"
+        );
         for range in &rates {
-            assert!(range.mMinimum > 0.0, "Sample rate minimum should be positive");
-            assert!(range.mMaximum >= range.mMinimum, "Maximum should be >= minimum");
+            assert!(
+                range.mMinimum > 0.0,
+                "Sample rate minimum should be positive"
+            );
+            assert!(
+                range.mMaximum >= range.mMinimum,
+                "Maximum should be >= minimum"
+            );
         }
     }
 }
@@ -605,9 +614,7 @@ pub fn get_supported_physical_stream_formats(
 /// Returns a vector of [`AudioValueRange`] where each entry describes a supported range.
 /// For devices that support discrete rates, `mMinimum` and `mMaximum` will be equal.
 /// For devices that support continuous ranges, they will differ.
-pub fn get_available_sample_rates(
-    device_id: AudioDeviceID,
-) -> Result<Vec<AudioValueRange>, Error> {
+pub fn get_available_sample_rates(device_id: AudioDeviceID) -> Result<Vec<AudioValueRange>, Error> {
     let property_address = AudioObjectPropertyAddress {
         mSelector: kAudioDevicePropertyAvailableNominalSampleRates,
         mScope: kAudioObjectPropertyScopeGlobal,

--- a/src/audio_unit/macos_helpers.rs
+++ b/src/audio_unit/macos_helpers.rs
@@ -621,22 +621,28 @@ pub fn get_available_sample_rates(device_id: AudioDeviceID) -> Result<Vec<AudioV
         mElement: kAudioObjectPropertyElementMaster,
     };
 
-    unsafe {
-        let mut data_size = 0u32;
-        let status = AudioObjectGetPropertyDataSize(
+    let mut data_size = 0u32;
+    // SAFETY: AudioObjectGetPropertyDataSize is a CoreAudio C API that reads
+    // the size of the property data into data_size. All pointers passed are
+    // valid stack references via NonNull::from.
+    let status = unsafe {
+        AudioObjectGetPropertyDataSize(
             device_id,
             NonNull::from(&property_address),
             0,
             null(),
             NonNull::from(&mut data_size),
-        );
-        Error::from_os_status(status)?;
+        )
+    };
+    Error::from_os_status(status)?;
 
-        let n_ranges = data_size as usize / mem::size_of::<AudioValueRange>();
-        let mut ranges: Vec<AudioValueRange> = vec![];
-        ranges.reserve_exact(n_ranges);
+    let n_ranges = data_size as usize / mem::size_of::<AudioValueRange>();
+    let mut ranges: Vec<AudioValueRange> = Vec::with_capacity(n_ranges);
+    // SAFETY: AudioObjectGetPropertyData writes exactly n_ranges elements
+    // (validated by data_size from the previous call) into the pre-allocated
+    // buffer. AudioValueRange is a plain C struct with no drop semantics.
+    unsafe {
         ranges.set_len(n_ranges);
-
         let status = AudioObjectGetPropertyData(
             device_id,
             NonNull::from(&property_address),
@@ -646,8 +652,8 @@ pub fn get_available_sample_rates(device_id: AudioDeviceID) -> Result<Vec<AudioV
             NonNull::new(ranges.as_mut_ptr()).unwrap().cast(),
         );
         Error::from_os_status(status)?;
-        Ok(ranges)
     }
+    Ok(ranges)
 }
 
 /// Get the transport type of a device.
@@ -661,20 +667,24 @@ pub fn get_device_transport_type(device_id: AudioDeviceID) -> Result<u32, Error>
         mElement: kAudioObjectPropertyElementMaster,
     };
 
-    unsafe {
-        let mut transport_type: u32 = 0;
-        let data_size = mem::size_of::<u32>() as u32;
-        let status = AudioObjectGetPropertyData(
+    let mut transport_type: u32 = 0;
+    let data_size = mem::size_of::<u32>() as u32;
+    // SAFETY: AudioObjectGetPropertyData is a CoreAudio C API that reads
+    // the transport type (a u32) into transport_type. All pointers passed
+    // are valid stack references via NonNull::from. data_size matches the
+    // size of the output buffer.
+    let status = unsafe {
+        AudioObjectGetPropertyData(
             device_id,
             NonNull::from(&property_address),
             0,
             null(),
             NonNull::from(&data_size),
             NonNull::from(&mut transport_type).cast(),
-        );
-        Error::from_os_status(status)?;
-        Ok(transport_type)
-    }
+        )
+    };
+    Error::from_os_status(status)?;
+    Ok(transport_type)
 }
 
 /// Changing the sample rate is an asynchronous process.


### PR DESCRIPTION
## Summary

Adds two new helper functions to `macos_helpers`:

- **`get_available_sample_rates(device_id)`** — queries `kAudioDevicePropertyAvailableNominalSampleRates` and returns the supported sample rate ranges as `Vec<AudioValueRange>`. For devices with discrete rates, `mMinimum == mMaximum`; for continuous ranges, they differ.

- **`get_device_transport_type(device_id)`** — queries `kAudioDevicePropertyTransportType` and returns the transport type constant (`kAudioDeviceTransportTypeUSB`, `kAudioDeviceTransportTypeBuiltIn`, etc.).

## Motivation

These are commonly needed when building audio applications that probe device capabilities — for example:
- Implementing automatic sample rate switching (matching track sample rate to device)
- Distinguishing USB DACs from built-in speakers or Bluetooth devices (to conditionally enable exclusive/hog mode)
- Displaying device capabilities in a settings UI

The sample rate ranges are already queried internally by `set_device_sample_rate`, but aren't exposed as a standalone function. The transport type property has no existing wrapper.

Both functions follow the same patterns as the existing helpers (`get_device_name`, `get_hogging_pid`, etc.).

## Test plan

- [x] `test_get_available_sample_rates` — verifies the default output device returns at least one rate range with valid min/max values
- [x] `test_get_device_transport_type` — verifies the default output device returns a transport type without error
- [x] All existing tests continue to pass